### PR TITLE
Use prefixes less often

### DIFF
--- a/src/cammainwindow.cpp
+++ b/src/cammainwindow.cpp
@@ -506,7 +506,7 @@ void CamMainWindow::updateCurrentSettingsLabel()
 	char battStr[50];
 	char fpsString[30];
 	char expString[30];
-	getSIText(fpsString, 1.0 / camera->sensor->getCurrentFramePeriodDouble(), 4, DEF_SI_OPTS, 10);
+	sprintf(fpsString, QString::number(1 / camera->sensor->getCurrentFramePeriodDouble()).toAscii());
 	getSIText(expString, camera->sensor->getCurrentExposureDouble(), 4, DEF_SI_OPTS, 10);
 	UInt32 expPercent = camera->sensor->getCurrentExposureDouble() * 100 / camera->sensor->getCurrentFramePeriodDouble();
 

--- a/src/recsettingswindow.cpp
+++ b/src/recsettingswindow.cpp
@@ -141,8 +141,7 @@ RecSettingsWindow::RecSettingsWindow(QWidget *parent, Camera * cameraInst) :
 
 	//Set the frame rate
 	double frameRate = 1.0 / framePeriod;
-	getSIText(str, frameRate, ceil(log10(framePeriod*100000000.0)+1), DEF_SI_OPTS, 1000);
-	ui->lineRate->setText(str);
+	ui->lineRate->setText(QString::number(frameRate));
 
 	//Set the exposure
     double exposure = (double)is->exposure / 100000000.0;
@@ -353,9 +352,7 @@ void RecSettingsWindow::on_cmdMax_clicked()
 
 	double frameRate = 1.0 / framePeriod;
 	qDebug() << frameRate;
-	getSIText(str, frameRate, ceil(log10(framePeriod * 100000000.0)+1), DEF_SI_OPTS, 1000);
-
-	ui->lineRate->setText(str);
+	ui->lineRate->setText(QString::number(frameRate));
 
 	//Make sure exposure is within limits
 	double exp = camera->sensor->getActualIntegrationTime(siText2Double(ui->lineExp->text().toStdString().c_str()),
@@ -423,10 +420,8 @@ void RecSettingsWindow::on_linePeriod_returnPressed()
 
 	//Set the frame rate
 	double frameRate = 1.0 / framePeriod;
-	qDebug() << frameRate;
-	getSIText(str, frameRate, ceil(log10(framePeriod*100000000.0)+1), DEF_SI_OPTS, 1000);
 
-	ui->lineRate->setText(str);
+	ui->lineRate->setText(QString::number(frameRate));
 
 	//Make sure exposure is within limits
 	double exp = camera->sensor->getActualIntegrationTime(siText2Double(ui->lineExp->text().toStdString().c_str()),
@@ -510,9 +505,8 @@ void RecSettingsWindow::on_lineRate_returnPressed()
 	//Refill the frame rate box with the nicely formatted value
 	frameRate = 1.0 / framePeriod;
 	qDebug() << frameRate;
-	getSIText(str, frameRate, ceil(log10(framePeriod * 100000000.0)+1), DEF_SI_OPTS, 1000);
 
-	ui->lineRate->setText(str);
+	ui->lineRate->setText(QString::number(frameRate));
 
 	//Make sure exposure is within limits
 	double exp = camera->sensor->getActualIntegrationTime(siText2Double(ui->lineExp->text().toStdString().c_str()),

--- a/src/siText.c
+++ b/src/siText.c
@@ -39,7 +39,7 @@ void getSIText(char * buf, double val, UInt32 sigfigs, UInt32 options, Int32 res
 
 	if(val != 0)
 		{
-		if(val >= 1000.0)
+		if(val >= 10000.0)
 		{
 			do {
 				val /= 1000.0;


### PR DESCRIPTION
Changes siText.c so that the prefixes for large numbers (k, M, etc) are only used for numbers over 10000.
For example, after setting the resolution to 1280x1024, the FPS will show as "1057.362" FPS  instead of "1.057 36 k" fps on the record settings window, and "1057.4 fps" on the main window.