### PR TITLE
Focus aid changes

### DIFF
--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -413,6 +413,7 @@ CameraErrortype Camera::init(GPMC * gpmcInst, Video * vinstInst, LUX1310 * senso
 
 	setZebraEnable(appSettings.value("camera/zebra", true).toBool());;
 	setFocusPeakEnable(appSettings.value("camera/focusPeak", false).toBool());;
+	setFocusPeakColorLL(getFocusPeakColor());
 
 	printf("Video init done\n");
 
@@ -2989,6 +2990,20 @@ void Camera::setFocusPeakEnable(bool en)
 	setFocusPeakEnableLL(en);
 	focusPeakEnabled = en;
 	appSettings.setValue("camera/focusPeak", en);
+}
+
+int Camera::getFocusPeakColor(){
+	QSettings appSettings;
+	qDebug()<< "getFocusPeakColor() " << appSettings.value("camera/focusPeakColorIndex", 2);
+	return appSettings.value("camera/focusPeakColorIndex", 2).toInt();//default setting of 3 is cyan
+}
+
+void Camera::setFocusPeakColor(int value){
+	QSettings appSettings;
+	setFocusPeakColorLL(value);
+	focusPeakColorIndex = value;
+	appSettings.setValue("camera/focusPeakColorIndex", value);
+	qDebug()<< "setFocusPeakColor() " << value;
 }
 
 

--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -2995,7 +2995,6 @@ void Camera::setFocusPeakEnable(bool en)
 
 int Camera::getFocusPeakColor(){
 	QSettings appSettings;
-	qDebug()<< "getFocusPeakColor() " << appSettings.value("camera/focusPeakColorIndex", 2);
 	return appSettings.value("camera/focusPeakColorIndex", 2).toInt();//default setting of 3 is cyan
 }
 
@@ -3004,7 +3003,6 @@ void Camera::setFocusPeakColor(int value){
 	setFocusPeakColorLL(value);
 	focusPeakColorIndex = value;
 	appSettings.setValue("camera/focusPeakColorIndex", value);
-	qDebug()<< "setFocusPeakColor() " << value;
 }
 
 

--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -414,6 +414,7 @@ CameraErrortype Camera::init(GPMC * gpmcInst, Video * vinstInst, LUX1310 * senso
 	setZebraEnable(appSettings.value("camera/zebra", true).toBool());;
 	setFocusPeakEnable(appSettings.value("camera/focusPeak", false).toBool());;
 	setFocusPeakColorLL(getFocusPeakColor());
+	setFocusPeakThresholdLL(appSettings.value("camera/focusPeakThreshold", 25).toUInt());
 
 	printf("Video init done\n");
 

--- a/src/camera.h
+++ b/src/camera.h
@@ -275,8 +275,8 @@ private:
 public:
 	bool getFocusPeakEnableLL(void);
 	void setFocusPeakEnableLL(bool en);
-	UInt8 getFocusPeakColor(void);
-	void setFocusPeakColor(UInt8 color);
+	UInt8 getFocusPeakColorLL(void);
+	void setFocusPeakColorLL(UInt8 color);
 	bool getZebraEnableLL(void);
 	void setZebraEnableLL(bool en);
 	void setFocusPeakThreshold(UInt32 thresh);
@@ -312,6 +312,7 @@ private:
 	double wbMat[3];	//Actual white balance computed during runtime
 	double imgGain;
 	bool focusPeakEnabled;
+	int focusPeakColorIndex;
 	bool zebraEnabled;
 	char serialNumber[SERIAL_NUMBER_MAX_LEN+1];
 
@@ -332,6 +333,8 @@ public:
 	bool RotationArgumentIsSet();
 	void upsideDownTransform(int rotation);
 	void updateVideoPosition();
+	int getFocusPeakColor();
+	void setFocusPeakColor(int value);
 private:
 	bool lastRecording;
 	bool terminateRecDataThread;

--- a/src/camera.h
+++ b/src/camera.h
@@ -279,8 +279,8 @@ public:
 	void setFocusPeakColorLL(UInt8 color);
 	bool getZebraEnableLL(void);
 	void setZebraEnableLL(bool en);
-	void setFocusPeakThreshold(UInt32 thresh);
-	UInt32 getFocusPeakThreshold(void);
+	void setFocusPeakThresholdLL(UInt32 thresh);
+	UInt32 getFocusPeakThresholdLL(void);
     Int32 getRamSizeGB(UInt32 * stick0SizeGB, UInt32 * stick1SizeGB);
 	Int32 readSerialNumber(char * dest);
 	Int32 writeSerialNumber(char * src);

--- a/src/cameraLowLevel.cpp
+++ b/src/cameraLowLevel.cpp
@@ -326,12 +326,12 @@ void Camera::setZebraEnableLL(bool en)
 	gpmc->write32(DISPLAY_CTL_ADDR, (reg & ~DISPLAY_CTL_ZEBRA_EN_MASK) | (en ? DISPLAY_CTL_ZEBRA_EN_MASK : 0));
 }
 
-void Camera::setFocusPeakThreshold(UInt32 thresh)
+void Camera::setFocusPeakThresholdLL(UInt32 thresh)
 {
 	gpmc->write32(DISPLAY_PEAKING_THRESH_ADDR, thresh);
 }
 
-UInt32 Camera::getFocusPeakThreshold(void)
+UInt32 Camera::getFocusPeakThresholdLL(void)
 {
 	return gpmc->read32(DISPLAY_PEAKING_THRESH_ADDR);
 }

--- a/src/cameraLowLevel.cpp
+++ b/src/cameraLowLevel.cpp
@@ -299,14 +299,14 @@ void Camera::setFocusPeakEnableLL(bool en)
 }
 
 
-UInt8 Camera::getFocusPeakColor(void)
+UInt8 Camera::getFocusPeakColorLL(void)
 {
 	return (gpmc->read32(DISPLAY_CTL_ADDR) & DISPLAY_CTL_FOCUS_PEAK_COLOR_MASK) >> DISPLAY_CTL_FOCUS_PEAK_COLOR_OFFSET;
 }
 
 
 
-void Camera::setFocusPeakColor(UInt8 color)
+void Camera::setFocusPeakColorLL(UInt8 color)
 {
 	UInt32 reg = gpmc->read32(DISPLAY_CTL_ADDR);
 	gpmc->write32(DISPLAY_CTL_ADDR, (reg & ~DISPLAY_CTL_FOCUS_PEAK_COLOR_MASK) | ((color & 7) << DISPLAY_CTL_FOCUS_PEAK_COLOR_OFFSET));

--- a/src/cammainwindow.cpp
+++ b/src/cammainwindow.cpp
@@ -469,18 +469,9 @@ void CamMainWindow::on_MainWindowTimeoutTimer()
 	ui->lblExp->setVisible(false);*/
 }
 
-void CamMainWindow::on_cmdFocusAid_clicked()
+void CamMainWindow::on_cmdFocusAid_clicked(bool focusAidEnabled)
 {
-	camera->setFocusPeakEnable(!focusAidEnabled);
-	focusAidEnabled = !focusAidEnabled;
-	if(focusAidEnabled)
-	{
-		ui->cmdFocusAid->setText("Focus\nAid (On)");
-	}
-	else
-	{
-		ui->cmdFocusAid->setText("Focus\nAid");
-	}
+	camera->setFocusPeakEnable(focusAidEnabled);
 }
 
 void CamMainWindow::on_expSlider_sliderMoved(int position)

--- a/src/cammainwindow.cpp
+++ b/src/cammainwindow.cpp
@@ -93,6 +93,7 @@ CamMainWindow::CamMainWindow(QWidget *parent) :
 	ui->expSlider->setMaximum(camera->sensor->getMaxCurrentIntegrationTime() * 100000000.0);
 	ui->expSlider->setValue(camera->sensor->getIntegrationTime() * 100000000.0);
 	ui->cmdWB->setEnabled(camera->getIsColor());
+	ui->cmdFocusAid->setChecked(camera->getFocusPeakEnable());
 
 	const char * myfifo = "/var/run/bmsFifo";
 

--- a/src/cammainwindow.cpp
+++ b/src/cammainwindow.cpp
@@ -93,7 +93,7 @@ CamMainWindow::CamMainWindow(QWidget *parent) :
 	ui->expSlider->setMaximum(camera->sensor->getMaxCurrentIntegrationTime() * 100000000.0);
 	ui->expSlider->setValue(camera->sensor->getIntegrationTime() * 100000000.0);
 	ui->cmdWB->setEnabled(camera->getIsColor());
-	ui->cmdFocusAid->setChecked(camera->getFocusPeakEnable());
+	ui->chkFocusAid->setChecked(camera->getFocusPeakEnable());
 
 	const char * myfifo = "/var/run/bmsFifo";
 
@@ -119,7 +119,7 @@ CamMainWindow::CamMainWindow(QWidget *parent) :
 		ui->cmdClose->setVisible(false);
 		ui->cmdDPCButton->setVisible(false);
 	}
-/*	ui->cmdFocusAid->setVisible(false);
+/*	ui->chkFocusAid->setVisible(false);
 	ui->cmdFPNCal->setVisible(false);
 	ui->cmdIOSettings->setVisible(false);
 	ui->cmdPlay->setVisible(false);
@@ -456,7 +456,7 @@ void CamMainWindow::on_MainWindowTimer()
 void CamMainWindow::on_MainWindowTimeoutTimer()
 {
 	menuTimeoutTimer->stop();
-/*	ui->cmdFocusAid->setVisible(false);
+/*	ui->chkFocusAid->setVisible(false);
 	ui->cmdFPNCal->setVisible(false);
 	ui->cmdIOSettings->setVisible(false);
 	ui->cmdPlay->setVisible(false);
@@ -470,7 +470,7 @@ void CamMainWindow::on_MainWindowTimeoutTimer()
 	ui->lblExp->setVisible(false);*/
 }
 
-void CamMainWindow::on_cmdFocusAid_clicked(bool focusAidEnabled)
+void CamMainWindow::on_chkFocusAid_clicked(bool focusAidEnabled)
 {
 	camera->setFocusPeakEnable(focusAidEnabled);
 }
@@ -540,7 +540,7 @@ void CamMainWindow::on_cmdUtil_clicked()
 }
 
 void CamMainWindow::UtilWindow_closed(){
-	ui->cmdFocusAid->setChecked(camera->getFocusPeakEnable());
+	ui->chkFocusAid->setChecked(camera->getFocusPeakEnable());
 }
 
 void CamMainWindow::updateCamMainWindowPosition(){
@@ -551,7 +551,7 @@ void CamMainWindow::updateCamMainWindowPosition(){
 
 void CamMainWindow::on_cmdBkGndButton_clicked()
 {
-	ui->cmdFocusAid->setVisible(true);
+	ui->chkFocusAid->setVisible(true);
 	ui->cmdFPNCal->setVisible(true);
 	ui->cmdIOSettings->setVisible(true);
 	ui->cmdPlay->setVisible(true);

--- a/src/cammainwindow.cpp
+++ b/src/cammainwindow.cpp
@@ -535,6 +535,11 @@ void CamMainWindow::on_cmdUtil_clicked()
 	w->setAttribute(Qt::WA_DeleteOnClose);
 	w->show();
 	connect(w, SIGNAL(moveCamMainWindow()), this, SLOT(updateCamMainWindowPosition()));
+	connect(w, SIGNAL(destroyed()), this, SLOT(UtilWindow_closed()));
+}
+
+void CamMainWindow::UtilWindow_closed(){
+	ui->cmdFocusAid->setChecked(camera->getFocusPeakEnable());
 }
 
 void CamMainWindow::updateCamMainWindowPosition(){

--- a/src/cammainwindow.h
+++ b/src/cammainwindow.h
@@ -63,7 +63,7 @@ private slots:
 
 	void on_MainWindowTimeoutTimer();
 
-	void on_cmdFocusAid_clicked();
+	void on_cmdFocusAid_clicked(bool focusAidEnabled);
 
 	void on_expSlider_sliderMoved(int position);
 

--- a/src/cammainwindow.h
+++ b/src/cammainwindow.h
@@ -63,7 +63,7 @@ private slots:
 
 	void on_MainWindowTimeoutTimer();
 
-	void on_cmdFocusAid_clicked(bool focusAidEnabled);
+	void on_chkFocusAid_clicked(bool focusAidEnabled);
 
 	void UtilWindow_closed();
 

--- a/src/cammainwindow.h
+++ b/src/cammainwindow.h
@@ -33,7 +33,7 @@ class CamMainWindow;
 class CamMainWindow : public QDialog
 {
 	Q_OBJECT
-	
+
 public:
 	explicit CamMainWindow(QWidget *parent = 0);
 	~CamMainWindow();
@@ -64,6 +64,8 @@ private slots:
 	void on_MainWindowTimeoutTimer();
 
 	void on_cmdFocusAid_clicked(bool focusAidEnabled);
+
+	void UtilWindow_closed();
 
 	void on_expSlider_sliderMoved(int position);
 

--- a/src/cammainwindow.ui
+++ b/src/cammainwindow.ui
@@ -125,6 +125,9 @@
      <bold>true</bold>
     </font>
    </property>
+   <property name="autoFillBackground">
+    <bool>false</bool>
+   </property>
    <property name="text">
     <string>Record</string>
    </property>
@@ -235,7 +238,7 @@ Balance</string>
 Settings</string>
    </property>
   </widget>
-  <widget class="QPushButton" name="cmdFocusAid">
+  <widget class="QCheckBox" name="cmdFocusAid">
    <property name="geometry">
     <rect>
      <x>100</x>
@@ -250,6 +253,18 @@ Settings</string>
      <weight>75</weight>
      <bold>true</bold>
     </font>
+   </property>
+   <property name="autoFillBackground">
+    <bool>true</bool>
+   </property>
+   <property name="styleSheet">
+    <string notr="true">QCheckBox::indicator {
+     width: 28px;
+     height: 28px;
+}
+
+
+</string>
    </property>
    <property name="text">
     <string>Focus

--- a/src/cammainwindow.ui
+++ b/src/cammainwindow.ui
@@ -238,7 +238,7 @@ Balance</string>
 Settings</string>
    </property>
   </widget>
-  <widget class="QCheckBox" name="cmdFocusAid">
+  <widget class="QCheckBox" name="chkFocusAid">
    <property name="geometry">
     <rect>
      <x>100</x>
@@ -403,7 +403,7 @@ border-color: black;</string>
   <zorder>cmdFPNCal</zorder>
   <zorder>cmdWB</zorder>
   <zorder>cmdIOSettings</zorder>
-  <zorder>cmdFocusAid</zorder>
+  <zorder>chkFocusAid</zorder>
   <zorder>expSlider</zorder>
   <zorder>lblCurrent</zorder>
   <zorder>cmdClose</zorder>

--- a/src/utilwindow.cpp
+++ b/src/utilwindow.cpp
@@ -72,11 +72,11 @@ UtilWindow::UtilWindow(QWidget *parent, Camera * cameraInst) :
 	//ui->comboFPColor->setEnabled(true);
 	ui->chkZebraEnable->setChecked(camera->getZebraEnable());
 
-	if(camera->getFocusPeakThreshold() == FOCUS_PEAK_THRESH_HIGH)
+	if(camera->getFocusPeakThresholdLL() == FOCUS_PEAK_THRESH_HIGH)
 		ui->radioFPSensHigh->setChecked(true);
-	else if(camera->getFocusPeakThreshold() == FOCUS_PEAK_THRESH_MED)
+	else if(camera->getFocusPeakThresholdLL() == FOCUS_PEAK_THRESH_MED)
 		ui->radioFPSensMed->setChecked(true);
-	else if(camera->getFocusPeakThreshold() == FOCUS_PEAK_THRESH_LOW)
+	else if(camera->getFocusPeakThresholdLL() == FOCUS_PEAK_THRESH_LOW)
 		ui->radioFPSensLow->setChecked(true);
 
 
@@ -352,7 +352,7 @@ void UtilWindow::on_radioFPSensLow_toggled(bool checked)
 {
 	if(checked)
 	{
-		camera->setFocusPeakThreshold(FOCUS_PEAK_THRESH_LOW);
+		camera->setFocusPeakThresholdLL(FOCUS_PEAK_THRESH_LOW);
 	}
 }
 
@@ -360,7 +360,7 @@ void UtilWindow::on_radioFPSensMed_toggled(bool checked)
 {
 	if(checked)
 	{
-		camera->setFocusPeakThreshold(FOCUS_PEAK_THRESH_MED);
+		camera->setFocusPeakThresholdLL(FOCUS_PEAK_THRESH_MED);
 	}
 }
 
@@ -368,7 +368,7 @@ void UtilWindow::on_radioFPSensHigh_toggled(bool checked)
 {
 	if(checked)
 	{
-		camera->setFocusPeakThreshold(FOCUS_PEAK_THRESH_HIGH);
+		camera->setFocusPeakThresholdLL(FOCUS_PEAK_THRESH_HIGH);
 	}
 }
 

--- a/src/utilwindow.cpp
+++ b/src/utilwindow.cpp
@@ -353,7 +353,10 @@ void UtilWindow::on_radioFPSensLow_toggled(bool checked)
 	if(checked)
 	{
 		camera->setFocusPeakThresholdLL(FOCUS_PEAK_THRESH_LOW);
+		QSettings appSettings;
+		appSettings.setValue("camera/focusPeakThreshold", FOCUS_PEAK_THRESH_LOW);
 	}
+
 }
 
 void UtilWindow::on_radioFPSensMed_toggled(bool checked)
@@ -361,6 +364,8 @@ void UtilWindow::on_radioFPSensMed_toggled(bool checked)
 	if(checked)
 	{
 		camera->setFocusPeakThresholdLL(FOCUS_PEAK_THRESH_MED);
+		QSettings appSettings;
+		appSettings.setValue("camera/focusPeakThreshold", FOCUS_PEAK_THRESH_MED);
 	}
 }
 
@@ -369,6 +374,8 @@ void UtilWindow::on_radioFPSensHigh_toggled(bool checked)
 	if(checked)
 	{
 		camera->setFocusPeakThresholdLL(FOCUS_PEAK_THRESH_HIGH);
+		QSettings appSettings;
+		appSettings.setValue("camera/focusPeakThreshold", FOCUS_PEAK_THRESH_HIGH);
 	}
 }
 

--- a/src/utilwindow.cpp
+++ b/src/utilwindow.cpp
@@ -67,8 +67,8 @@ UtilWindow::UtilWindow(QWidget *parent, Camera * cameraInst) :
 	ui->comboFPColor->addItem("Magenta");
 	ui->comboFPColor->addItem("Yellow");
 	ui->comboFPColor->addItem("White");
-	ui->comboFPColor->setCurrentIndex(camera->getFocusPeakColor() - 1);
-	qDebug() << "Init set color combo index to" << camera->getFocusPeakColor() - 1;
+	ui->comboFPColor->setCurrentIndex(camera->getFocusPeakColorLL() - 1);
+	qDebug() << "Init set color combo index to" << camera->getFocusPeakColorLL() - 1;
 	//ui->comboFPColor->setEnabled(true);
 	ui->chkZebraEnable->setChecked(camera->getZebraEnable());
 

--- a/src/utilwindow.cpp
+++ b/src/utilwindow.cpp
@@ -68,8 +68,6 @@ UtilWindow::UtilWindow(QWidget *parent, Camera * cameraInst) :
 	ui->comboFPColor->addItem("Yellow");
 	ui->comboFPColor->addItem("White");
 	ui->comboFPColor->setCurrentIndex(camera->getFocusPeakColorLL() - 1);
-	qDebug() << "Init set color combo index to" << camera->getFocusPeakColorLL() - 1;
-	//ui->comboFPColor->setEnabled(true);
 	ui->chkZebraEnable->setChecked(camera->getZebraEnable());
 
 	if(camera->getFocusPeakThresholdLL() == FOCUS_PEAK_THRESH_HIGH)
@@ -345,7 +343,6 @@ void UtilWindow::on_comboFPColor_currentIndexChanged(int index)
 	if(ui->comboFPColor->count() < 7)	//Hack so the incorrect value doesn't get set during population of values
 		return;
 	camera->setFocusPeakColor(index + 1);
-	qDebug() << "Set focus peak color to" << index+1;
 }
 
 void UtilWindow::on_radioFPSensLow_toggled(bool checked)


### PR DESCRIPTION
-Changed focus aid control on CamMainWindow from pushbutton to checkbox
-Show correct status of focus peaking on UtilWindow upon its creation, and in CamMainWindow upon returning from UtilWindow
-Save and load settings for focus aid enabled, color and intensity