### PR TITLE
Change error message when trying to backup/restore calibration/settings without SD card

### DIFF
--- a/src/utilwindow.cpp
+++ b/src/utilwindow.cpp
@@ -525,7 +525,7 @@ void UtilWindow::on_cmdSetSN_clicked()
 
 void UtilWindow::statErrorMessage(){
 	QMessageBox msg;
-	msg.setText("stat() failed");
+	msg.setText("Error reading SD card");
 	msg.setWindowFlags(Qt::WindowStaysOnTopHint);
 	msg.exec();
 }

--- a/src/utilwindow.cpp
+++ b/src/utilwindow.cpp
@@ -523,6 +523,13 @@ void UtilWindow::on_cmdSetSN_clicked()
 	camera->writeSerialNumber(camera->getSerialNumber());
 }
 
+void UtilWindow::statErrorMessage(){
+	QMessageBox msg;
+	msg.setText("stat() failed");
+	msg.setWindowFlags(Qt::WindowStaysOnTopHint);
+	msg.exec();
+}
+
 void UtilWindow::on_cmdSaveCal_clicked()
 {
 	StatusWindow sw;
@@ -535,9 +542,7 @@ void UtilWindow::on_cmdSaveCal_clicked()
 	retVal = stat("/media/sda1",&st);
 	if(retVal != 0)
 	{
-		msg.setText("stat() failed");
-		msg.setWindowFlags(Qt::WindowStaysOnTopHint);
-		msg.exec();
+		statErrorMessage();
 		return;
 	}
 
@@ -607,9 +612,7 @@ void UtilWindow::on_cmdRestoreCal_clicked()
 	retVal = stat("/media/sda1",&st);
 	if(retVal != 0)
 	{
-		msg.setText("stat() failed");
-		msg.setWindowFlags(Qt::WindowStaysOnTopHint);
-		msg.exec();
+		statErrorMessage();
 		return;
 	}
 
@@ -766,9 +769,7 @@ void UtilWindow::on_cmdBackupSettings_clicked()
 	retVal = stat("/media/sda1",&st);
 	if(retVal != 0)
 	{
-		msg.setText("stat() failed");
-		msg.setWindowFlags(Qt::WindowStaysOnTopHint);
-		msg.exec();
+		statErrorMessage();
 		return;
 	}
 
@@ -835,9 +836,7 @@ void UtilWindow::on_cmdRestoreSettings_clicked()
 	retVal = stat("/media/sda1",&st);
 	if(retVal != 0)
 	{
-		msg.setText("stat() failed");
-		msg.setWindowFlags(Qt::WindowStaysOnTopHint);
-		msg.exec();
+		statErrorMessage();
 		return;
 	}
 

--- a/src/utilwindow.h
+++ b/src/utilwindow.h
@@ -100,6 +100,7 @@ private:
 	Camera * camera;
 	QTimer * timer;
 	bool settingClock;
+	void statErrorMessage();
 };
 
 #endif // UTILWINDOW_H


### PR DESCRIPTION
1. Improve the clarity of the error message shown when trying to backup or restore calibration or settings if an SD card is not inserted.
2. Move code for that error message to a separate function to prevent code being duplicated between 4 different places in utilwindow.cpp.