### PR TITLE
Playback slider - Keep area highlighted after aborting a save

### DIFF
--- a/src/playbackwindow.cpp
+++ b/src/playbackwindow.cpp
@@ -220,6 +220,8 @@ void playbackWindow::on_cmdSave_clicked()
 			ui->verticalSlider->appendRegionToList();
 			ui->verticalSlider->setHighlightRegion(markOutFrame, markOutFrame);
 			//both arguments should be markout because a new rectangle will be drawn, and it should not overlap the one that was just appended
+			markInFrameOld = markInFrame;
+			markInFrame = markOutFrame;
 		}
 		else
 		{
@@ -232,8 +234,11 @@ void playbackWindow::on_cmdSave_clicked()
 	}
 	else
 	{
+		//This block is executed when Abort is clicked
 		camera->recorder->stop2();
 		ui->verticalSlider->removeLastRegionFromList();
+		markInFrame = markInFrameOld;
+		ui->verticalSlider->setHighlightRegion(markInFrame, markOutFrame);
 	}
 
 }

--- a/src/playbackwindow.h
+++ b/src/playbackwindow.h
@@ -79,6 +79,7 @@ private:
 	void updatePlayRateLabel(Int32 playbackRate);
 	void setControlEnable(bool en);
 	UInt32 markInFrame, markOutFrame;
+	UInt32 markInFrameOld;
 	UInt32 lastPlayframe;
 	QTimer * timer;
 	QTimer * saveDoneTimer;


### PR DESCRIPTION
Previously, the highlighting for a region would be removed when the save was aborted, even though the start and end marks remained in place.