### PR TITLE
Change backup/restore calibration/settings error message again

### DIFF
--- a/src/utilwindow.cpp
+++ b/src/utilwindow.cpp
@@ -525,7 +525,7 @@ void UtilWindow::on_cmdSetSN_clicked()
 
 void UtilWindow::statErrorMessage(){
 	QMessageBox msg;
-	msg.setText("Error reading SD card");
+	msg.setText("Error: USB device (/media/sda1) not present");
 	msg.setWindowFlags(Qt::WindowStaysOnTopHint);
 	msg.exec();
 }

--- a/src/utilwindow.cpp
+++ b/src/utilwindow.cpp
@@ -525,7 +525,7 @@ void UtilWindow::on_cmdSetSN_clicked()
 
 void UtilWindow::statErrorMessage(){
 	QMessageBox msg;
-	msg.setText("Error: USB device (/media/sda1) not present");
+	msg.setText("Error: USB device not detected"); // /media/sda1
 	msg.setWindowFlags(Qt::WindowStaysOnTopHint);
 	msg.exec();
 }


### PR DESCRIPTION
Change statErrorMessage() to notify user about lack of USB device instead of SD card, as these can only be saved to and read from USB.