### PR TITLE
Disable Abort button on playback window when close to video end to prevent crashes.

### DIFF
--- a/src/playbackwindow.cpp
+++ b/src/playbackwindow.cpp
@@ -178,12 +178,6 @@ void playbackWindow::on_cmdSave_clicked()
 				if(QMessageBox::Yes != reply)
 					return;
 			}
-
-			/* Prevent the user from pressing the abort/save button just after the last frame,
-			 * as that can make the camera try to save a 2nd video too soon, crashing the camapp.
-			 * It is also disabled in checkForSaveDone(), but if the video is very short,
-			 * that might not be called at all before the end of the video, so just disable the button right away.*/
-			if(markOutFrame - markInFrame < 10) ui->cmdSave->setEnabled(false);
 		}
 
 		//Check that the path exists
@@ -222,9 +216,17 @@ void playbackWindow::on_cmdSave_clicked()
 			setControlEnable(false);
 			sw->setText("Saving...");
 			sw->show();
+
 			saveDoneTimer = new QTimer(this);
 			connect(saveDoneTimer, SIGNAL(timeout()), this, SLOT(checkForSaveDone()));
 			saveDoneTimer->start(100);
+
+			/* Prevent the user from pressing the abort/save button just after the last frame,
+			 * as that can make the camera try to save a 2nd video too soon, crashing the camapp.
+			 * It is also disabled in checkForSaveDone(), but if the video is very short,
+			 * that might not be called at all before the end of the video, so just disable the button right away.*/
+			if(markOutFrame - markInFrame < 25) ui->cmdSave->setEnabled(false);
+
 			ui->verticalSlider->appendRegionToList();
 			ui->verticalSlider->setHighlightRegion(markOutFrame, markOutFrame);
 			//both arguments should be markout because a new rectangle will be drawn, and it should not overlap the one that was just appended
@@ -339,7 +341,7 @@ void playbackWindow::checkForSaveDone()
 
 		/* Prevent the user from pressing the abort/save button just after the last frame,
 		 * as that can make the camera try to save a 2nd video too soon, crashing the camapp.*/
-		if(camera->playFrame >= markOutFrame - 10)
+		if(camera->playFrame >= markOutFrame - 25)
 			ui->cmdSave->setEnabled(false);
 	}
 }

--- a/src/playbackwindow.cpp
+++ b/src/playbackwindow.cpp
@@ -178,6 +178,12 @@ void playbackWindow::on_cmdSave_clicked()
 				if(QMessageBox::Yes != reply)
 					return;
 			}
+
+			/* Prevent the user from pressing the abort/save button just after the last frame,
+			 * as that can make the camera try to save a 2nd video too soon, crashing the camapp.
+			 * It is also disabled in checkForSaveDone(), but if the video is very short,
+			 * that might not be called at all before the end of the video, so just disable the button right away.*/
+			if(markOutFrame - markInFrame < 10) ui->cmdSave->setEnabled(false);
 		}
 
 		//Check that the path exists
@@ -318,6 +324,7 @@ void playbackWindow::checkForSaveDone()
 		sw->close();
 		ui->cmdSave->setText("Save");
 		setControlEnable(true);
+		ui->cmdSave->setEnabled(true);
 		updatePlayRateLabel(playbackRate);
 
 		if(autoSaveFlag) {
@@ -329,6 +336,11 @@ void playbackWindow::checkForSaveDone()
 		sprintf(tmp, "%.1ffps", camera->recorder->getFramerate());
 		ui->lblFrameRate->setText(tmp);
 		setControlEnable(false);
+
+		/* Prevent the user from pressing the abort/save button just after the last frame,
+		 * as that can make the camera try to save a 2nd video too soon, crashing the camapp.*/
+		if(camera->playFrame >= markOutFrame - 10)
+			ui->cmdSave->setEnabled(false);
 	}
 }
 


### PR DESCRIPTION
As it stands, If the user presses the Abort button just after the end of saving a video (that is, presses it a fraction of a second after the handle on the vertical slider stops moving upwards), the camApp can crash and the video will be replaced with a grey screen.
I made the Abort button disabled during the time period when pressing it may cause crashes.