### PR TITLE
Savesettings window changes

### DIFF
--- a/src/playbackwindow.cpp
+++ b/src/playbackwindow.cpp
@@ -224,6 +224,7 @@ void playbackWindow::on_cmdSave_clicked()
 			//both arguments should be markout because a new rectangle will be drawn, and it should not overlap the one that was just appended
 			markInFrameOld = markInFrame;
 			markInFrame = markOutFrame;
+			emit enableSaveSettingsButtons(false);
 		}
 		else
 		{
@@ -260,6 +261,7 @@ void playbackWindow::on_cmdSaveSettings_clicked()
 	ui->cmdSaveSettings->setEnabled(false);
 	ui->cmdClose->setEnabled(false);
 	connect(w, SIGNAL(destroyed()), this, SLOT(saveSettingsClosed()));
+	connect(this, SIGNAL(enableSaveSettingsButtons(bool)), w, SLOT(setControlEnable(bool)));
 }
 
 void playbackWindow::saveSettingsClosed(){
@@ -318,6 +320,7 @@ void playbackWindow::checkForSaveDone()
 		sw->close();
 		ui->cmdSave->setText("Save");
 		setControlEnable(true);
+		emit enableSaveSettingsButtons(true);
 		updatePlayRateLabel(playbackRate);
 
 		if(autoSaveFlag) {

--- a/src/playbackwindow.h
+++ b/src/playbackwindow.h
@@ -89,6 +89,7 @@ private:
 
 signals:
 	void finishedSaving();
+	void enableSaveSettingsButtons(bool);
 };
 
 #endif // PLAYBACKWINDOW_H

--- a/src/savesettingswindow.cpp
+++ b/src/savesettingswindow.cpp
@@ -124,15 +124,9 @@ saveSettingsWindow::~saveSettingsWindow()
 void saveSettingsWindow::on_cmdClose_clicked()
 {
 	QSettings settings;
-	camera->recorder->bitsPerPixel = ui->spinBitrate->value();
-	camera->recorder->maxBitrate = ui->spinMaxBitrate->value();
-	camera->recorder->framerate = ui->spinFramerate->value();
+
 	camera->recorder->profile = 1 << ui->comboProfile->currentIndex();
 	camera->recorder->level = 1 << ui->comboLevel->currentIndex();
-
-	settings.setValue("recorder/saveFormat", ui->comboSaveFormat->currentIndex());
-		
-	strcpy(camera->recorder->filename, ui->lineFilename->text().toStdString().c_str());
 
 	//Keep the beginning of the combo box text (the path)
 	char str[100];
@@ -150,10 +144,6 @@ void saveSettingsWindow::on_cmdClose_clicked()
 
 	strcpy(camera->recorder->fileDirectory, path);
 
-	settings.setValue("recorder/bitsPerPixel", camera->recorder->bitsPerPixel);
-	settings.setValue("recorder/maxBitrate", camera->recorder->maxBitrate);
-	settings.setValue("recorder/framerate", camera->recorder->framerate);
-	settings.setValue("recorder/filename", camera->recorder->filename);
 	settings.setValue("recorder/fileDirectory", camera->recorder->fileDirectory);
 	settings.setValue("recorder/profile", camera->recorder->profile);
 	settings.setValue("recorder/level", camera->recorder->level);
@@ -331,11 +321,17 @@ void saveSettingsWindow::updateBitrate()
 void saveSettingsWindow::on_spinBitrate_valueChanged(double arg1)
 {
 	updateBitrate();
+	QSettings settings;
+	camera->recorder->bitsPerPixel = ui->spinBitrate->value();
+	settings.setValue("recorder/bitsPerPixel", camera->recorder->bitsPerPixel);
 }
 
 void saveSettingsWindow::on_spinFramerate_valueChanged(int arg1)
 {
 	updateBitrate();
+	QSettings settings;
+	camera->recorder->framerate = ui->spinFramerate->value();
+	settings.setValue("recorder/framerate", camera->recorder->framerate);
 }
 
 //When the number of drives connected changes, refresh the drive list
@@ -372,11 +368,19 @@ void saveSettingsWindow::updateDrives(void)
 
 }
 
-
+void saveSettingsWindow::on_lineFilename_textEdited(const QString &arg1)
+{
+	QSettings settings;
+	strcpy(camera->recorder->filename, ui->lineFilename->text().toStdString().c_str());
+	settings.setValue("recorder/filename", camera->recorder->filename);
+}
 
 void saveSettingsWindow::on_spinMaxBitrate_valueChanged(int arg1)
 {
 	updateBitrate();
+	QSettings settings;
+	camera->recorder->maxBitrate = ui->spinMaxBitrate->value();
+	settings.setValue("recorder/maxBitrate", camera->recorder->maxBitrate);
 }
 
 void saveSettingsWindow::on_comboSaveFormat_currentIndexChanged(int index)
@@ -393,6 +397,8 @@ void saveSettingsWindow::on_comboSaveFormat_currentIndexChanged(int index)
 		ui->spinMaxBitrate->setEnabled(false);
 	}
 	updateBitrate();
+	QSettings settings;
+	settings.setValue("recorder/saveFormat", ui->comboSaveFormat->currentIndex());
 }
 
 void saveSettingsWindow::setControlEnable(bool en){

--- a/src/savesettingswindow.cpp
+++ b/src/savesettingswindow.cpp
@@ -111,6 +111,7 @@ saveSettingsWindow::saveSettingsWindow(QWidget *parent, Camera * camInst) :
 	timer = new QTimer(this);
 	connect(timer, SIGNAL(timeout()), this, SLOT(updateDrives()));
 	timer->start(1000);
+	comboDriveStatus = 1;
 
 }
 
@@ -128,6 +129,15 @@ void saveSettingsWindow::on_cmdClose_clicked()
 	camera->recorder->profile = 1 << ui->comboProfile->currentIndex();
 	camera->recorder->level = 1 << ui->comboLevel->currentIndex();
 
+	saveFileDirectory();
+
+	settings.setValue("recorder/profile", camera->recorder->profile);
+	settings.setValue("recorder/level", camera->recorder->level);
+
+	close();
+}
+
+void saveSettingsWindow::saveFileDirectory(){
 	//Keep the beginning of the combo box text (the path)
 	char str[100];
 	const char * path;
@@ -143,12 +153,8 @@ void saveSettingsWindow::on_cmdClose_clicked()
 		path = "";
 
 	strcpy(camera->recorder->fileDirectory, path);
-
+	QSettings settings;
 	settings.setValue("recorder/fileDirectory", camera->recorder->fileDirectory);
-	settings.setValue("recorder/profile", camera->recorder->profile);
-	settings.setValue("recorder/level", camera->recorder->level);
-
-	close();
 }
 
 void saveSettingsWindow::on_cmdUMount_clicked()
@@ -411,4 +417,10 @@ void saveSettingsWindow::setControlEnable(bool en){
 	ui->cmdRefresh->setEnabled(en);
 	ui->cmdUMount->setEnabled(en);
 	ui->cmdClose->setEnabled(en);
+}
+
+void saveSettingsWindow::on_comboDrive_currentIndexChanged(const QString &arg1)
+{
+	if(comboDriveStatus == 2) saveFileDirectory();
+	if(comboDriveStatus == 1) comboDriveStatus = 2;//Hack to prevent crash when 2 storage devices (SD and usb drive) are connected while creating a new savesettingswindow for the first time.
 }

--- a/src/savesettingswindow.cpp
+++ b/src/savesettingswindow.cpp
@@ -189,6 +189,7 @@ void saveSettingsWindow::refreshDriveList()
 	char drive[1024];		//Stores string to be placed in combo box
 	UInt32 len;
 
+	comboDriveStatus = 0;
 	ui->comboDrive->clear();
 
 	//ui->comboDrive->addItem("/");
@@ -287,7 +288,7 @@ void saveSettingsWindow::refreshDriveList()
 		ui->comboDrive->setEnabled(false);
 
 	}
-
+	comboDriveStatus = 2;
 }
 
 void saveSettingsWindow::on_cmdRefresh_clicked()

--- a/src/savesettingswindow.cpp
+++ b/src/savesettingswindow.cpp
@@ -188,7 +188,7 @@ void saveSettingsWindow::refreshDriveList()
 	char drive[1024];		//Stores string to be placed in combo box
 	UInt32 len;
 
-	comboDriveStatus = false;
+	okToSaveLocation = false;//prevent saving a new value while drive list is being updated
 	ui->comboDrive->clear();
 
 	//ui->comboDrive->addItem("/");
@@ -287,7 +287,7 @@ void saveSettingsWindow::refreshDriveList()
 		ui->comboDrive->setEnabled(false);
 
 	}
-	comboDriveStatus = true;
+	okToSaveLocation = true;
 }
 
 void saveSettingsWindow::on_cmdRefresh_clicked()
@@ -421,5 +421,5 @@ void saveSettingsWindow::setControlEnable(bool en){
 
 void saveSettingsWindow::on_comboDrive_currentIndexChanged(const QString &arg1)
 {
-	if(comboDriveStatus) saveFileDirectory();
+	if(okToSaveLocation) saveFileDirectory();
 }

--- a/src/savesettingswindow.cpp
+++ b/src/savesettingswindow.cpp
@@ -421,6 +421,13 @@ void saveSettingsWindow::setControlEnable(bool en){
 
 void saveSettingsWindow::on_comboDrive_currentIndexChanged(const QString &arg1)
 {
+	/*Hack to prevent crash when 2 storage devices (SD and usb drive) are connected while creating a new savesettingswindow for the first time.
+	meaning of comboDriveStatus values:
+	0: window init not complete, so don't do anything yet.
+	1: on_comboDrive_currentIndexChanged() is somehow called twice even after window init is complete.
+		Calling saveFileDirectory() in those cases can cause a crash.  Seems to be from the strcpy function trying to copy the string " " into camera->recorder->fileDirectory
+	2: OK to call saveFileDirectory() at this point
+	*/
 	if(comboDriveStatus == 2) saveFileDirectory();
-	if(comboDriveStatus == 1) comboDriveStatus = 2;//Hack to prevent crash when 2 storage devices (SD and usb drive) are connected while creating a new savesettingswindow for the first time.
+	if(comboDriveStatus == 1) comboDriveStatus = 2;
 }

--- a/src/savesettingswindow.cpp
+++ b/src/savesettingswindow.cpp
@@ -111,7 +111,6 @@ saveSettingsWindow::saveSettingsWindow(QWidget *parent, Camera * camInst) :
 	timer = new QTimer(this);
 	connect(timer, SIGNAL(timeout()), this, SLOT(updateDrives()));
 	timer->start(1000);
-	comboDriveStatus = 1;
 
 }
 
@@ -189,7 +188,7 @@ void saveSettingsWindow::refreshDriveList()
 	char drive[1024];		//Stores string to be placed in combo box
 	UInt32 len;
 
-	comboDriveStatus = 0;
+	comboDriveStatus = false;
 	ui->comboDrive->clear();
 
 	//ui->comboDrive->addItem("/");
@@ -288,7 +287,7 @@ void saveSettingsWindow::refreshDriveList()
 		ui->comboDrive->setEnabled(false);
 
 	}
-	comboDriveStatus = 2;
+	comboDriveStatus = true;
 }
 
 void saveSettingsWindow::on_cmdRefresh_clicked()
@@ -422,13 +421,5 @@ void saveSettingsWindow::setControlEnable(bool en){
 
 void saveSettingsWindow::on_comboDrive_currentIndexChanged(const QString &arg1)
 {
-	/*Hack to prevent crash when 2 storage devices (SD and usb drive) are connected while creating a new savesettingswindow for the first time.
-	meaning of comboDriveStatus values:
-	0: window init not complete, so don't do anything yet.
-	1: on_comboDrive_currentIndexChanged() is somehow called twice even after window init is complete.
-		Calling saveFileDirectory() in those cases can cause a crash.  Seems to be from the strcpy function trying to copy the string " " into camera->recorder->fileDirectory
-	2: OK to call saveFileDirectory() at this point
-	*/
-	if(comboDriveStatus == 2) saveFileDirectory();
-	if(comboDriveStatus == 1) comboDriveStatus = 2;
+	if(comboDriveStatus) saveFileDirectory();
 }

--- a/src/savesettingswindow.cpp
+++ b/src/savesettingswindow.cpp
@@ -394,3 +394,15 @@ void saveSettingsWindow::on_comboSaveFormat_currentIndexChanged(int index)
 	}
 	updateBitrate();
 }
+
+void saveSettingsWindow::setControlEnable(bool en){
+	ui->spinBitrate->setEnabled(en);
+	ui->spinFramerate->setEnabled(en);
+	ui->spinMaxBitrate->setEnabled(en);
+	ui->lineFilename->setEnabled(en);
+	ui->comboSaveFormat->setEnabled(en);
+	ui->comboDrive->setEnabled(en);
+	ui->cmdRefresh->setEnabled(en);
+	ui->cmdUMount->setEnabled(en);
+	ui->cmdClose->setEnabled(en);
+}

--- a/src/savesettingswindow.h
+++ b/src/savesettingswindow.h
@@ -57,6 +57,8 @@ private slots:
 
     void on_comboSaveFormat_currentIndexChanged(int index);
 
+    void on_lineFilename_textEdited(const QString &arg1);
+
 private:
 	void refreshDriveList();
 	void updateBitrate();

--- a/src/savesettingswindow.h
+++ b/src/savesettingswindow.h
@@ -69,7 +69,7 @@ private:
 	Ui::saveSettingsWindow *ui;
 	QTimer * timer;
 	UInt32 driveCount;
-	unsigned short comboDriveStatus = 0;
+	bool comboDriveStatus = false;
 };
 
 #endif // SAVESETTINGSWINDOW_H

--- a/src/savesettingswindow.h
+++ b/src/savesettingswindow.h
@@ -59,13 +59,17 @@ private slots:
 
     void on_lineFilename_textEdited(const QString &arg1);
 
+    void on_comboDrive_currentIndexChanged(const QString &arg1);
+
 private:
 	void refreshDriveList();
 	void updateBitrate();
+	void saveFileDirectory();
 
 	Ui::saveSettingsWindow *ui;
 	QTimer * timer;
 	UInt32 driveCount;
+	unsigned short comboDriveStatus = 0;
 };
 
 #endif // SAVESETTINGSWINDOW_H

--- a/src/savesettingswindow.h
+++ b/src/savesettingswindow.h
@@ -69,7 +69,7 @@ private:
 	Ui::saveSettingsWindow *ui;
 	QTimer * timer;
 	UInt32 driveCount;
-	bool comboDriveStatus = false;
+	bool okToSaveLocation = false;
 };
 
 #endif // SAVESETTINGSWINDOW_H

--- a/src/savesettingswindow.h
+++ b/src/savesettingswindow.h
@@ -38,6 +38,8 @@ public:
 	char filename[1000];
 	Camera * camera;
 
+public slots:
+	void setControlEnable(bool en);
 private slots:
 	void on_cmdClose_clicked();
 

--- a/src/savesettingswindow.ui
+++ b/src/savesettingswindow.ui
@@ -413,8 +413,7 @@ QDoubleSpinBox::down-button { subcontrol-position: right; width: 40px; height: 3
     </font>
    </property>
    <property name="text">
-    <string>Apply/
-Close</string>
+    <string>Close</string>
    </property>
   </widget>
   <widget class="QPushButton" name="cmdUMount">

--- a/src/savesettingswindow.ui
+++ b/src/savesettingswindow.ui
@@ -403,7 +403,8 @@ QDoubleSpinBox::down-button { subcontrol-position: right; width: 40px; height: 3
     </rect>
    </property>
    <property name="text">
-    <string>Close</string>
+    <string>Apply/
+Close</string>
    </property>
   </widget>
   <widget class="QPushButton" name="cmdUMount">
@@ -423,11 +424,6 @@ Remove</string>
  </widget>
  <customwidgets>
   <customwidget>
-   <class>CamLineEdit</class>
-   <extends>QLineEdit</extends>
-   <header>camLineEdit.h</header>
-  </customwidget>
-  <customwidget>
    <class>CamSpinBox</class>
    <extends>QSpinBox</extends>
    <header>camspinbox.h</header>
@@ -436,6 +432,11 @@ Remove</string>
    <class>CamDoubleSpinBox</class>
    <extends>QDoubleSpinBox</extends>
    <header>camdoublespinbox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>CamLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>camLineEdit.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/src/savesettingswindow.ui
+++ b/src/savesettingswindow.ui
@@ -388,6 +388,11 @@ QDoubleSpinBox::down-button { subcontrol-position: right; width: 40px; height: 3
       <height>31</height>
      </rect>
     </property>
+    <property name="font">
+     <font>
+      <pointsize>13</pointsize>
+     </font>
+    </property>
     <property name="text">
      <string>Refresh</string>
     </property>
@@ -402,6 +407,11 @@ QDoubleSpinBox::down-button { subcontrol-position: right; width: 40px; height: 3
      <height>51</height>
     </rect>
    </property>
+   <property name="font">
+    <font>
+     <pointsize>13</pointsize>
+    </font>
+   </property>
    <property name="text">
     <string>Apply/
 Close</string>
@@ -415,6 +425,11 @@ Close</string>
      <width>91</width>
      <height>41</height>
     </rect>
+   </property>
+   <property name="font">
+    <font>
+     <pointsize>13</pointsize>
+    </font>
    </property>
    <property name="text">
     <string>Safely


### PR DESCRIPTION
1. Enlarge the text on the 3 pushbuttons (Apply/Close, Safely Remove, and Refresh).
2. Disable buttons on savesettings window while save is occuring to prevent settings from being changed during save.
3. Save bitsPerPixel, maxBitrate, saved file framerate, format, filename and save location as soon as they are changed instead of when the Close button is pressed.