### PR TITLE
Fix bugs related to exposure values

### DIFF
--- a/src/cammainwindow.cpp
+++ b/src/cammainwindow.cpp
@@ -90,7 +90,7 @@ CamMainWindow::CamMainWindow(QWidget *parent) :
 	qDebug() << "camera->sensor->getMaxCurrentIntegrationTime() returned" << camera->sensor->getMaxCurrentIntegrationTime();
 
 	ui->expSlider->setMinimum(LUX1310_MIN_INT_TIME * 100000000.0);
-	ui->expSlider->setMaximum(camera->sensor->getMaxCurrentIntegrationTime() * 100000000.0);
+	ui->expSlider->setMaximum(camera->sensor->getMaxCurrentIntegrationTime() * 100000000.0 - 20);
 	ui->expSlider->setValue(camera->sensor->getIntegrationTime() * 100000000.0);
 	ui->cmdWB->setEnabled(camera->getIsColor());
 	ui->chkFocusAid->setChecked(camera->getFocusPeakEnable());
@@ -489,7 +489,7 @@ void CamMainWindow::on_expSlider_sliderMoved(int position)
 void CamMainWindow::recSettingsClosed()
 {
 	ui->expSlider->setMinimum(LUX1310_MIN_INT_TIME * 100000000.0);
-	ui->expSlider->setMaximum(camera->sensor->getMaxCurrentIntegrationTime() * 100000000.0);
+	ui->expSlider->setMaximum(camera->sensor->getMaxCurrentIntegrationTime() * 100000000.0 - 20);
 	ui->expSlider->setValue(camera->sensor->getIntegrationTime() * 100000000.0);
 	updateCurrentSettingsLabel();
 }

--- a/src/cammainwindow.cpp
+++ b/src/cammainwindow.cpp
@@ -503,7 +503,8 @@ void CamMainWindow::updateCurrentSettingsLabel()
 	char expString[30];
 	sprintf(fpsString, QString::number(1 / camera->sensor->getCurrentFramePeriodDouble()).toAscii());
 	getSIText(expString, camera->sensor->getCurrentExposureDouble(), 4, DEF_SI_OPTS, 10);
-	UInt32 expPercent = camera->sensor->getCurrentExposureDouble() * 100 / camera->sensor->getCurrentFramePeriodDouble();
+	UInt32 expPercent = camera->sensor->getCurrentExposureDouble() * 100 / (camera->sensor->getMaxCurrentIntegrationTime());
+	expPercent = max(expPercent, 1);//to prevent 0% from showing on the label if the current exposure is less than 1% of the max exposure(happens on 1280x1024)
 
 	double battPercent = (flags & 4) ?	//If battery is charging
 						within(((double)battVoltageCam/1000.0 - 10.75) / (12.4 - 10.75) * 80, 0.0, 80.0) +

--- a/src/recsettingswindow.cpp
+++ b/src/recsettingswindow.cpp
@@ -202,7 +202,7 @@ void RecSettingsWindow::on_cmdOK_clicked()
 														  ui->spinVRes->value());
 
 
-    is->exposure = exp * 100000000.0;
+    is->exposure = exp * 100000000.0 - 20;
 
     is->temporary = 0;
     camera->setImagerSettings(*is);


### PR DESCRIPTION
1. Fix the % value shown for the shutter slider so it can show 100%
2. Prevent being able to set exposure to 101% if fps is 38k (max value for exposure slider was being set too high)
3. Prevents an incremental increase in exposure time every time the record settings window's OK button is pressed. (it seems that some math in LUX1310::setSlaveExposure was causing the currentExposure member in sensor to increase its value).