### PR TITLE
More keyboard changes

### DIFF
--- a/src/keyboard.cpp
+++ b/src/keyboard.cpp
@@ -125,7 +125,7 @@ void keyboard::buttonClicked(QWidget *w)
 	{
 		shift = false;
 		ui->shift->setStyleSheet(QString(""));
-		setLowercase();
+		if(!capslock) setLowercase();
 	}
 }
 
@@ -135,7 +135,7 @@ void keyboard::on_caps_clicked()
 	{
 		capslock = false;
 		ui->caps->setStyleSheet(QString(""));
-		setLowercase();
+		if(!shift) setLowercase();
 	}
 	else
 	{
@@ -156,7 +156,7 @@ void keyboard::on_shift_clicked()
 	{
 		shift = false;
 		ui->shift->setStyleSheet(QString(""));
-		setLowercase();
+		if(!capslock) setLowercase();
 	}
 	else
 	{

--- a/src/keyboard.cpp
+++ b/src/keyboard.cpp
@@ -123,9 +123,7 @@ void keyboard::buttonClicked(QWidget *w)
 	emit characterGenerated(capslock || shift ? chr : chr.toLower());
 	if(shift)
 	{
-		shift = false;
-		ui->shift->setStyleSheet(QString(""));
-		if(!capslock) setLowercase();
+		on_shift_clicked();
 	}
 }
 
@@ -136,12 +134,14 @@ void keyboard::on_caps_clicked()
 		capslock = false;
 		ui->caps->setStyleSheet(QString(""));
 		if(!shift) setLowercase();
+		else setUppercase();
 	}
 	else
 	{
 		capslock = true;
 		ui->caps->setStyleSheet(QString(KEYBOARD_BACKGROUND_BUTTON));
-		setUppercase();
+		if(shift)setLowercase();
+		else setUppercase();
 	}
 }
 
@@ -157,12 +157,14 @@ void keyboard::on_shift_clicked()
 		shift = false;
 		ui->shift->setStyleSheet(QString(""));
 		if(!capslock) setLowercase();
+		else setUppercase();
 	}
 	else
 	{
 		shift = true;
 		ui->shift->setStyleSheet(QString(KEYBOARD_BACKGROUND_BUTTON));
-		setUppercase();
+		if(capslock) setLowercase();
+		else setUppercase();
 	}
 }
 

--- a/src/keyboard.cpp
+++ b/src/keyboard.cpp
@@ -23,6 +23,7 @@ keyboard::keyboard(QWidget *parent) :
 {
 	ui->setupUi(this);
 	capslock = shift = false;
+	setLowercase();
 
 	connect(qApp, SIGNAL(focusChanged(QWidget*,QWidget*)),
 			this, SLOT(saveFocusWidget(QWidget*,QWidget*)));

--- a/src/keyboard.cpp
+++ b/src/keyboard.cpp
@@ -125,6 +125,7 @@ void keyboard::buttonClicked(QWidget *w)
 	{
 		shift = false;
 		ui->shift->setStyleSheet(QString(""));
+		setLowercase();
 	}
 }
 
@@ -134,11 +135,13 @@ void keyboard::on_caps_clicked()
 	{
 		capslock = false;
 		ui->caps->setStyleSheet(QString(""));
+		setLowercase();
 	}
 	else
 	{
 		capslock = true;
 		ui->caps->setStyleSheet(QString(KEYBOARD_BACKGROUND_BUTTON));
+		setUppercase();
 	}
 }
 
@@ -153,11 +156,70 @@ void keyboard::on_shift_clicked()
 	{
 		shift = false;
 		ui->shift->setStyleSheet(QString(""));
+		setLowercase();
 	}
 	else
 	{
 		shift = true;
 		ui->shift->setStyleSheet(QString(KEYBOARD_BACKGROUND_BUTTON));
+		setUppercase();
 	}
 }
 
+void keyboard::setUppercase(){
+	ui->Q->setText("Q");
+	ui->W->setText("W");
+	ui->E->setText("E");
+	ui->R->setText("R");
+	ui->T->setText("T");
+	ui->Y->setText("Y");
+	ui->U->setText("U");
+	ui->I->setText("I");
+	ui->O->setText("O");
+	ui->P->setText("P");
+	ui->A->setText("A");
+	ui->S->setText("S");
+	ui->D->setText("D");
+	ui->F->setText("F");
+	ui->G->setText("G");
+	ui->H->setText("H");
+	ui->J->setText("J");
+	ui->K->setText("K");
+	ui->L->setText("L");
+	ui->Z->setText("Z");
+	ui->X->setText("X");
+	ui->C->setText("C");
+	ui->V->setText("V");
+	ui->B->setText("B");
+	ui->N->setText("N");
+	ui->M->setText("M");
+}
+
+void keyboard::setLowercase(){
+	ui->Q->setText("q");
+	ui->W->setText("w");
+	ui->E->setText("e");
+	ui->R->setText("r");
+	ui->T->setText("t");
+	ui->Y->setText("y");
+	ui->U->setText("u");
+	ui->I->setText("i");
+	ui->O->setText("o");
+	ui->P->setText("p");
+	ui->A->setText("a");
+	ui->S->setText("s");
+	ui->D->setText("d");
+	ui->F->setText("f");
+	ui->G->setText("g");
+	ui->H->setText("h");
+	ui->J->setText("j");
+	ui->K->setText("k");
+	ui->L->setText("l");
+	ui->Z->setText("z");
+	ui->X->setText("x");
+	ui->C->setText("c");
+	ui->V->setText("v");
+	ui->B->setText("b");
+	ui->N->setText("n");
+	ui->M->setText("m");
+}

--- a/src/keyboard.cpp
+++ b/src/keyboard.cpp
@@ -22,7 +22,7 @@ keyboard::keyboard(QWidget *parent) :
 	ui(new Ui::keyboard)
 {
 	ui->setupUi(this);
-	capslock = false;
+	capslock = shift = false;
 
 	connect(qApp, SIGNAL(focusChanged(QWidget*,QWidget*)),
 			this, SLOT(saveFocusWidget(QWidget*,QWidget*)));

--- a/src/keyboard.h
+++ b/src/keyboard.h
@@ -53,6 +53,8 @@ private:
 	Ui::keyboard *ui;
 	bool capslock;
 	bool shift;
+	void setUppercase();
+	void setLowercase();
 };
 
 #endif // KEYBOARD_H

--- a/src/keyboard.ui
+++ b/src/keyboard.ui
@@ -30,7 +30,7 @@
    </property>
    <property name="font">
     <font>
-     <pointsize>14</pointsize>
+     <pointsize>20</pointsize>
      <weight>75</weight>
      <italic>false</italic>
      <bold>true</bold>
@@ -51,7 +51,7 @@
    </property>
    <property name="font">
     <font>
-     <pointsize>14</pointsize>
+     <pointsize>28</pointsize>
      <weight>75</weight>
      <italic>false</italic>
      <bold>true</bold>
@@ -72,7 +72,7 @@
    </property>
    <property name="font">
     <font>
-     <pointsize>14</pointsize>
+     <pointsize>28</pointsize>
      <weight>75</weight>
      <italic>false</italic>
      <bold>true</bold>
@@ -93,7 +93,7 @@
    </property>
    <property name="font">
     <font>
-     <pointsize>14</pointsize>
+     <pointsize>28</pointsize>
      <weight>75</weight>
      <italic>false</italic>
      <bold>true</bold>
@@ -114,7 +114,7 @@
    </property>
    <property name="font">
     <font>
-     <pointsize>14</pointsize>
+     <pointsize>20</pointsize>
      <weight>75</weight>
      <italic>false</italic>
      <bold>true</bold>
@@ -135,7 +135,7 @@
    </property>
    <property name="font">
     <font>
-     <pointsize>14</pointsize>
+     <pointsize>28</pointsize>
      <weight>75</weight>
      <italic>false</italic>
      <bold>true</bold>
@@ -156,7 +156,7 @@
    </property>
    <property name="font">
     <font>
-     <pointsize>14</pointsize>
+     <pointsize>28</pointsize>
      <weight>75</weight>
      <italic>false</italic>
      <bold>true</bold>
@@ -177,7 +177,7 @@
    </property>
    <property name="font">
     <font>
-     <pointsize>14</pointsize>
+     <pointsize>20</pointsize>
      <weight>75</weight>
      <italic>false</italic>
      <bold>true</bold>
@@ -201,7 +201,7 @@
    </property>
    <property name="font">
     <font>
-     <pointsize>14</pointsize>
+     <pointsize>28</pointsize>
      <weight>75</weight>
      <italic>false</italic>
      <bold>true</bold>
@@ -222,7 +222,7 @@
    </property>
    <property name="font">
     <font>
-     <pointsize>14</pointsize>
+     <pointsize>28</pointsize>
      <weight>75</weight>
      <italic>false</italic>
      <bold>true</bold>
@@ -243,7 +243,7 @@
    </property>
    <property name="font">
     <font>
-     <pointsize>14</pointsize>
+     <pointsize>28</pointsize>
      <weight>75</weight>
      <italic>false</italic>
      <bold>true</bold>
@@ -285,7 +285,7 @@
    </property>
    <property name="font">
     <font>
-     <pointsize>14</pointsize>
+     <pointsize>28</pointsize>
      <weight>75</weight>
      <italic>false</italic>
      <bold>true</bold>
@@ -306,7 +306,7 @@
    </property>
    <property name="font">
     <font>
-     <pointsize>14</pointsize>
+     <pointsize>28</pointsize>
      <weight>75</weight>
      <italic>false</italic>
      <bold>true</bold>
@@ -327,7 +327,7 @@
    </property>
    <property name="font">
     <font>
-     <pointsize>14</pointsize>
+     <pointsize>28</pointsize>
      <weight>75</weight>
      <italic>false</italic>
      <bold>true</bold>
@@ -348,7 +348,7 @@
    </property>
    <property name="font">
     <font>
-     <pointsize>14</pointsize>
+     <pointsize>28</pointsize>
      <weight>75</weight>
      <italic>false</italic>
      <bold>true</bold>
@@ -369,7 +369,7 @@
    </property>
    <property name="font">
     <font>
-     <pointsize>14</pointsize>
+     <pointsize>28</pointsize>
      <weight>75</weight>
      <italic>false</italic>
      <bold>true</bold>
@@ -390,7 +390,7 @@
    </property>
    <property name="font">
     <font>
-     <pointsize>14</pointsize>
+     <pointsize>28</pointsize>
      <weight>75</weight>
      <italic>false</italic>
      <bold>true</bold>
@@ -411,7 +411,7 @@
    </property>
    <property name="font">
     <font>
-     <pointsize>14</pointsize>
+     <pointsize>28</pointsize>
      <weight>75</weight>
      <italic>false</italic>
      <bold>true</bold>
@@ -432,7 +432,7 @@
    </property>
    <property name="font">
     <font>
-     <pointsize>14</pointsize>
+     <pointsize>28</pointsize>
      <weight>75</weight>
      <italic>false</italic>
      <bold>true</bold>
@@ -453,7 +453,7 @@
    </property>
    <property name="font">
     <font>
-     <pointsize>14</pointsize>
+     <pointsize>28</pointsize>
      <weight>75</weight>
      <italic>false</italic>
      <bold>true</bold>
@@ -474,7 +474,7 @@
    </property>
    <property name="font">
     <font>
-     <pointsize>14</pointsize>
+     <pointsize>28</pointsize>
      <weight>75</weight>
      <italic>false</italic>
      <bold>true</bold>
@@ -495,7 +495,7 @@
    </property>
    <property name="font">
     <font>
-     <pointsize>14</pointsize>
+     <pointsize>28</pointsize>
      <weight>75</weight>
      <italic>false</italic>
      <bold>true</bold>
@@ -516,7 +516,7 @@
    </property>
    <property name="font">
     <font>
-     <pointsize>14</pointsize>
+     <pointsize>28</pointsize>
      <weight>75</weight>
      <italic>false</italic>
      <bold>true</bold>
@@ -537,7 +537,7 @@
    </property>
    <property name="font">
     <font>
-     <pointsize>14</pointsize>
+     <pointsize>20</pointsize>
      <weight>75</weight>
      <italic>false</italic>
      <bold>true</bold>
@@ -558,7 +558,7 @@
    </property>
    <property name="font">
     <font>
-     <pointsize>14</pointsize>
+     <pointsize>28</pointsize>
      <weight>75</weight>
      <italic>false</italic>
      <bold>true</bold>
@@ -579,7 +579,7 @@
    </property>
    <property name="font">
     <font>
-     <pointsize>14</pointsize>
+     <pointsize>20</pointsize>
      <weight>75</weight>
      <italic>false</italic>
      <bold>true</bold>
@@ -600,7 +600,7 @@
    </property>
    <property name="font">
     <font>
-     <pointsize>14</pointsize>
+     <pointsize>28</pointsize>
      <weight>75</weight>
      <italic>false</italic>
      <bold>true</bold>
@@ -621,7 +621,7 @@
    </property>
    <property name="font">
     <font>
-     <pointsize>14</pointsize>
+     <pointsize>28</pointsize>
      <weight>75</weight>
      <italic>false</italic>
      <bold>true</bold>
@@ -642,7 +642,7 @@
    </property>
    <property name="font">
     <font>
-     <pointsize>14</pointsize>
+     <pointsize>28</pointsize>
      <weight>75</weight>
      <italic>false</italic>
      <bold>true</bold>
@@ -663,7 +663,7 @@
    </property>
    <property name="font">
     <font>
-     <pointsize>14</pointsize>
+     <pointsize>28</pointsize>
      <weight>75</weight>
      <italic>false</italic>
      <bold>true</bold>
@@ -684,7 +684,7 @@
    </property>
    <property name="font">
     <font>
-     <pointsize>14</pointsize>
+     <pointsize>28</pointsize>
      <weight>75</weight>
      <italic>false</italic>
      <bold>true</bold>
@@ -705,7 +705,7 @@
    </property>
    <property name="font">
     <font>
-     <pointsize>14</pointsize>
+     <pointsize>28</pointsize>
      <weight>75</weight>
      <italic>false</italic>
      <bold>true</bold>
@@ -726,7 +726,7 @@
    </property>
    <property name="font">
     <font>
-     <pointsize>14</pointsize>
+     <pointsize>28</pointsize>
      <weight>75</weight>
      <italic>false</italic>
      <bold>true</bold>
@@ -747,7 +747,7 @@
    </property>
    <property name="font">
     <font>
-     <pointsize>14</pointsize>
+     <pointsize>28</pointsize>
      <weight>75</weight>
      <italic>false</italic>
      <bold>true</bold>
@@ -768,7 +768,7 @@
    </property>
    <property name="font">
     <font>
-     <pointsize>14</pointsize>
+     <pointsize>28</pointsize>
      <weight>75</weight>
      <italic>false</italic>
      <bold>true</bold>
@@ -789,7 +789,7 @@
    </property>
    <property name="font">
     <font>
-     <pointsize>14</pointsize>
+     <pointsize>28</pointsize>
      <weight>75</weight>
      <italic>false</italic>
      <bold>true</bold>
@@ -810,7 +810,7 @@
    </property>
    <property name="font">
     <font>
-     <pointsize>14</pointsize>
+     <pointsize>28</pointsize>
      <weight>75</weight>
      <italic>false</italic>
      <bold>true</bold>
@@ -831,7 +831,7 @@
    </property>
    <property name="font">
     <font>
-     <pointsize>14</pointsize>
+     <pointsize>28</pointsize>
      <weight>75</weight>
      <italic>false</italic>
      <bold>true</bold>
@@ -852,7 +852,7 @@
    </property>
    <property name="font">
     <font>
-     <pointsize>14</pointsize>
+     <pointsize>28</pointsize>
      <weight>75</weight>
      <italic>false</italic>
      <bold>true</bold>
@@ -873,7 +873,7 @@
    </property>
    <property name="font">
     <font>
-     <pointsize>14</pointsize>
+     <pointsize>28</pointsize>
      <weight>75</weight>
      <italic>false</italic>
      <bold>true</bold>
@@ -894,7 +894,7 @@
    </property>
    <property name="font">
     <font>
-     <pointsize>14</pointsize>
+     <pointsize>28</pointsize>
      <weight>75</weight>
      <italic>false</italic>
      <bold>true</bold>
@@ -936,7 +936,7 @@
    </property>
    <property name="font">
     <font>
-     <pointsize>14</pointsize>
+     <pointsize>28</pointsize>
      <weight>75</weight>
      <italic>false</italic>
      <bold>true</bold>
@@ -957,7 +957,7 @@
    </property>
    <property name="font">
     <font>
-     <pointsize>14</pointsize>
+     <pointsize>28</pointsize>
      <weight>75</weight>
      <italic>false</italic>
      <bold>true</bold>
@@ -978,7 +978,7 @@
    </property>
    <property name="font">
     <font>
-     <pointsize>14</pointsize>
+     <pointsize>20</pointsize>
      <weight>75</weight>
      <italic>false</italic>
      <bold>true</bold>
@@ -999,7 +999,7 @@
    </property>
    <property name="font">
     <font>
-     <pointsize>14</pointsize>
+     <pointsize>28</pointsize>
      <weight>75</weight>
      <italic>false</italic>
      <bold>true</bold>


### PR DESCRIPTION
1. Change capitalization status of keys when changing shift or caps lock.
2. Set default value for shift too, not just caps lock.
3. Change behavior when both caps lock and shift are activated.  In this state, after a key is pressed, a lowercase key is now sent instead of an uppercase one, and the keyboard will return to uppercase letters.
4. Set keys to display lowercase letters by default.
5. Increase font size for all keys on alphanumeric keyboard, except Close.