### PR TITLE
White balance dialog

### DIFF
--- a/src/camApp.pro
+++ b/src/camApp.pro
@@ -92,7 +92,8 @@ SOURCES += main.cpp\
     triggerslider.cpp \
     playbackslider.cpp \
     keyboardbase.cpp \
-    keyboardnumeric.cpp
+    keyboardnumeric.cpp \
+    whitebalancedialog.cpp
 
 ## Generate version.cpp on every build
 versionTarget.target = version.cpp
@@ -149,7 +150,8 @@ HEADERS  += mainwindow.h \
     triggerslider.h \
     playbackslider.h \
     keyboardbase.h \
-    keyboardnumeric.h
+    keyboardnumeric.h \
+    whitebalancedialog.h
 
 
 
@@ -167,7 +169,8 @@ FORMS    += mainwindow.ui \
     statuswindow.ui \
     recmodewindow.ui \
     triggerdelaywindow.ui \
-    keyboardnumeric.ui
+    keyboardnumeric.ui \
+    whitebalancedialog.ui
 
 RESOURCES += \
     Images.qrc

--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -342,9 +342,9 @@ CameraErrortype Camera::init(GPMC * gpmcInst, Video * vinstInst, LUX1310 * senso
 		sceneWhiteBalMatrix[0] = sceneWhiteBalMatrix[1] = sceneWhiteBalMatrix[2] = 1.0;
 	}
 	else{
-		sceneWhiteBalMatrix[0] = appSettings.value("whiteBalance/currentR", 1.0).toDouble();
-		sceneWhiteBalMatrix[1] = appSettings.value("whiteBalance/currentG", 1.0).toDouble();
-		sceneWhiteBalMatrix[2] = appSettings.value("whiteBalance/currentB", 1.0).toDouble();
+		sceneWhiteBalMatrix[0] = appSettings.value("whiteBalance/currentR", 1.35).toDouble();//Use the values for average daylight by default.  See whitebalancedialog.cpp for the other presets.
+		sceneWhiteBalMatrix[1] = appSettings.value("whiteBalance/currentG", 1.00).toDouble();
+		sceneWhiteBalMatrix[2] = appSettings.value("whiteBalance/currentB", 1.584).toDouble();
 	}
 
 	qDebug() << gpmc->read16(CCM_11_ADDR) << gpmc->read16(CCM_12_ADDR) << gpmc->read16(CCM_13_ADDR);
@@ -2634,7 +2634,7 @@ Int32 Camera::setWhiteBalance(UInt32 x, UInt32 y)
 
 UInt8 Camera::getWBIndex(){
 	QSettings appsettings;
-	return appsettings.value("camera/WBIndex", 2).toUInt();
+	return appsettings.value("camera/WBIndex", 3).toUInt();
 }
 
 void Camera::setWBIndex(UInt8 index){

--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -343,9 +343,9 @@ CameraErrortype Camera::init(GPMC * gpmcInst, Video * vinstInst, LUX1310 * senso
 	}
 	else{
 		WBIndex = getWBIndex();
-		sceneWhiteBalMatrix[0] = preComputedWhiteBalMatrix[WBIndex][0];
-		sceneWhiteBalMatrix[1] = preComputedWhiteBalMatrix[WBIndex][1];
-		sceneWhiteBalMatrix[2] = preComputedWhiteBalMatrix[WBIndex][2];
+		sceneWhiteBalMatrix[0] = appSettings.value("whiteBalance/currentR", 1.0).toDouble();
+		sceneWhiteBalMatrix[1] = appSettings.value("whiteBalance/currentG", 1.0).toDouble();
+		sceneWhiteBalMatrix[2] = appSettings.value("whiteBalance/currentB", 1.0).toDouble();
 	}
 
 	qDebug() << gpmc->read16(CCM_11_ADDR) << gpmc->read16(CCM_12_ADDR) << gpmc->read16(CCM_13_ADDR);

--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -342,7 +342,6 @@ CameraErrortype Camera::init(GPMC * gpmcInst, Video * vinstInst, LUX1310 * senso
 		sceneWhiteBalMatrix[0] = sceneWhiteBalMatrix[1] = sceneWhiteBalMatrix[2] = 1.0;
 	}
 	else{
-		WBIndex = getWBIndex();
 		sceneWhiteBalMatrix[0] = appSettings.value("whiteBalance/currentR", 1.0).toDouble();
 		sceneWhiteBalMatrix[1] = appSettings.value("whiteBalance/currentG", 1.0).toDouble();
 		sceneWhiteBalMatrix[2] = appSettings.value("whiteBalance/currentB", 1.0).toDouble();
@@ -2640,7 +2639,6 @@ UInt8 Camera::getWBIndex(){
 
 void Camera::setWBIndex(UInt8 index){
 	QSettings appsettings;
-	WBIndex = index;
 	appsettings.setValue("camera/WBIndex", index);
 }
 

--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -342,9 +342,10 @@ CameraErrortype Camera::init(GPMC * gpmcInst, Video * vinstInst, LUX1310 * senso
 		sceneWhiteBalMatrix[0] = sceneWhiteBalMatrix[1] = sceneWhiteBalMatrix[2] = 1.0;
 	}
 	else{
-		sceneWhiteBalMatrix[0] = 1.21266;
-		sceneWhiteBalMatrix[1] = 1.0;
-		sceneWhiteBalMatrix[2] = 1.51712;
+		WBIndex = 4;
+		sceneWhiteBalMatrix[0] = preComputedWhiteBalMatrix[WBIndex][0];
+		sceneWhiteBalMatrix[1] = preComputedWhiteBalMatrix[WBIndex][1];
+		sceneWhiteBalMatrix[2] = preComputedWhiteBalMatrix[WBIndex][2];
 	}
 
 	qDebug() << gpmc->read16(CCM_11_ADDR) << gpmc->read16(CCM_12_ADDR) << gpmc->read16(CCM_13_ADDR);

--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -2634,7 +2634,7 @@ Int32 Camera::setWhiteBalance(UInt32 x, UInt32 y)
 
 UInt8 Camera::getWBIndex(){
 	QSettings appsettings;
-	return appsettings.value("camera/WBIndex", 3).toUInt();
+	return appsettings.value("camera/WBIndex", 2).toUInt();
 }
 
 void Camera::setWBIndex(UInt8 index){

--- a/src/camera.cpp
+++ b/src/camera.cpp
@@ -342,7 +342,7 @@ CameraErrortype Camera::init(GPMC * gpmcInst, Video * vinstInst, LUX1310 * senso
 		sceneWhiteBalMatrix[0] = sceneWhiteBalMatrix[1] = sceneWhiteBalMatrix[2] = 1.0;
 	}
 	else{
-		WBIndex = 4;
+		WBIndex = getWBIndex();
 		sceneWhiteBalMatrix[0] = preComputedWhiteBalMatrix[WBIndex][0];
 		sceneWhiteBalMatrix[1] = preComputedWhiteBalMatrix[WBIndex][1];
 		sceneWhiteBalMatrix[2] = preComputedWhiteBalMatrix[WBIndex][2];
@@ -2632,6 +2632,18 @@ Int32 Camera::setWhiteBalance(UInt32 x, UInt32 y)
 	return SUCCESS;
 
 }
+
+UInt8 Camera::getWBIndex(){
+	QSettings appsettings;
+	return appsettings.value("camera/WBIndex", 2).toUInt();
+}
+
+void Camera::setWBIndex(UInt8 index){
+	QSettings appsettings;
+	WBIndex = index;
+	appsettings.setValue("camera/WBIndex", index);
+}
+
 
 void Camera::setFocusAid(bool enable)
 {

--- a/src/camera.h
+++ b/src/camera.h
@@ -330,15 +330,6 @@ private:
 		-0.0614, -0.6409, +1.5258,
 	};
 	double cameraWhiteBalMatrix[3] = { 1.15177, 1.09279, 1.0 };
-	UInt8  WBIndex;
-	double preComputedWhiteBalMatrix[6][3] = {//[6][3] instead of [5][3] to allow extra space for custom white balance
-										 {1.25, 1.0, 1.50},//manual white balance set by user
-										 {1.0, 1.0, 1.0},
-										 {1.0, 1.0, 1.0},
-										 {1.0, 1.0, 1.0},
-										 {1.0, 1.0, 1.0},
-										 {1.21266, 1.0, 1.51712}//domestic lighting
-									 };//Pre-computed white balance options
 	double imgGain;
 	bool focusPeakEnabled;
 	int focusPeakColorIndex;

--- a/src/camera.h
+++ b/src/camera.h
@@ -347,6 +347,8 @@ private:
 	char serialNumber[SERIAL_NUMBER_MAX_LEN+1];
 
 public:
+	UInt8 getWBIndex();
+	void  setWBIndex(UInt8 index);
 	int unsavedWarnEnabled;
 	bool videoHasBeenReviewed;
 	bool autoSave;

--- a/src/camera.h
+++ b/src/camera.h
@@ -331,6 +331,15 @@ private:
 	};
 	double cameraWhiteBalMatrix[3] = { 1, 1.1, 1.3 };
 	double sceneWhiteBalMatrix[3];	//Actual white balance computed during runtime
+	UInt8  WBIndex;
+	double preComputedWhiteBalMatrix[6][3] = {//[6][3] instead of [5][3] to allow extra space for custom white balance
+										 {1.25, 1.0, 1.50},//manual white balance set by user
+										 {1.0, 1.0, 1.0},
+										 {1.0, 1.0, 1.0},
+										 {1.0, 1.0, 1.0},
+										 {1.0, 1.0, 1.0},
+										 {1.21266, 1.0, 1.51712}//domestic lighting
+									 };//Pre-computed white balance options
 	double imgGain;
 	bool focusPeakEnabled;
 	int focusPeakColorIndex;

--- a/src/camera.h
+++ b/src/camera.h
@@ -330,7 +330,6 @@ private:
 		-0.0614, -0.6409, +1.5258,
 	};
 	double cameraWhiteBalMatrix[3] = { 1.15177, 1.09279, 1.0 };
-	double sceneWhiteBalMatrix[3];	//Actual white balance computed during runtime
 	UInt8  WBIndex;
 	double preComputedWhiteBalMatrix[6][3] = {//[6][3] instead of [5][3] to allow extra space for custom white balance
 										 {1.25, 1.0, 1.50},//manual white balance set by user
@@ -347,6 +346,7 @@ private:
 	char serialNumber[SERIAL_NUMBER_MAX_LEN+1];
 
 public:
+	double sceneWhiteBalMatrix[3];	//Actual white balance computed during runtime
 	UInt8 getWBIndex();
 	void  setWBIndex(UInt8 index);
 	int unsavedWarnEnabled;

--- a/src/cammainwindow.cpp
+++ b/src/cammainwindow.cpp
@@ -30,6 +30,7 @@
 #include "utilwindow.h"
 //#include "statuswindow.h"
 #include "cammainwindow.h"
+#include "whitebalancedialog.h"
 #include "ui_cammainwindow.h"
 #include "util.h"
 

--- a/src/cammainwindow.cpp
+++ b/src/cammainwindow.cpp
@@ -324,6 +324,9 @@ void CamMainWindow::on_cmdWB_clicked()
 		sw->show();
 	}*/
 		whiteBalanceDialog *whiteBalWindow = new whiteBalanceDialog(NULL, camera);
+		whiteBalWindow->setAttribute(Qt::WA_DeleteOnClose);
+		whiteBalWindow->show();
+		whiteBalWindow->setModal(true);
 }
 
 void CamMainWindow::on_cmdIOSettings_clicked()

--- a/src/cammainwindow.cpp
+++ b/src/cammainwindow.cpp
@@ -299,34 +299,23 @@ void CamMainWindow::on_cmdFPNCal_clicked()//Black cal
 
 void CamMainWindow::on_cmdWB_clicked()
 {
-
-	/*
+	if(camera->getIsRecording()) {
 		QMessageBox::StandardButton reply;
-		if(camera->getIsRecording()) reply = QMessageBox::question(this, "Stop recording?", "This action will stop recording and erase the video; is this okay?", QMessageBox::Yes|QMessageBox::No);
-		else						 reply = QMessageBox::question(this, "Set white balance?", "Will set white balance. Continue?", QMessageBox::Yes|QMessageBox::No);
-
+		reply = QMessageBox::question(this, "Stop recording?", "This action will stop recording and erase the video; is this okay?", QMessageBox::Yes|QMessageBox::No);
 		if(QMessageBox::Yes != reply)
 			return;
 		autoSaveActive = false;
 		camera->stopRecording();
-	Int32 ret = camera->setWhiteBalance(camera->getImagerSettings().hRes / 2 & 0xFFFFFFFE,
-							camera->getImagerSettings().vRes / 2 & 0xFFFFFFFE);	//Sample from middle but make sure position is a multiple of 2
-	if(ret == CAMERA_CLIPPED_ERROR)
-	{
-		sw->setText("Clipping. Reduce exposure and try white balance again");
-		sw->setTimeout(3000);
-		sw->show();
+		delayms(100);
 	}
-	else if(ret == CAMERA_LOW_SIGNAL_ERROR)
-	{
-		sw->setText("Too dark. Increase exposure and try white balance again");
-		sw->setTimeout(3000);
-		sw->show();
-	}*/
-		whiteBalanceDialog *whiteBalWindow = new whiteBalanceDialog(NULL, camera);
-		whiteBalWindow->setAttribute(Qt::WA_DeleteOnClose);
-		whiteBalWindow->show();
-		whiteBalWindow->setModal(true);
+	autoSaveActive = false;
+	camera->stopRecording();
+
+	whiteBalanceDialog *whiteBalWindow = new whiteBalanceDialog(NULL, camera);
+	whiteBalWindow->setAttribute(Qt::WA_DeleteOnClose);
+	whiteBalWindow->show();
+	whiteBalWindow->setModal(true);
+	//whiteBalWindow->move(camera->ButtonsOnLeft? 0:600, 0);
 }
 
 void CamMainWindow::on_cmdIOSettings_clicked()

--- a/src/cammainwindow.cpp
+++ b/src/cammainwindow.cpp
@@ -33,6 +33,7 @@
 #include "whitebalancedialog.h"
 #include "ui_cammainwindow.h"
 #include "util.h"
+#include "whitebalancedialog.h"
 
 extern "C" {
 #include "siText.h"
@@ -299,6 +300,7 @@ void CamMainWindow::on_cmdFPNCal_clicked()//Black cal
 void CamMainWindow::on_cmdWB_clicked()
 {
 
+	/*
 		QMessageBox::StandardButton reply;
 		if(camera->getIsRecording()) reply = QMessageBox::question(this, "Stop recording?", "This action will stop recording and erase the video; is this okay?", QMessageBox::Yes|QMessageBox::No);
 		else						 reply = QMessageBox::question(this, "Set white balance?", "Will set white balance. Continue?", QMessageBox::Yes|QMessageBox::No);
@@ -307,7 +309,6 @@ void CamMainWindow::on_cmdWB_clicked()
 			return;
 		autoSaveActive = false;
 		camera->stopRecording();
-
 	Int32 ret = camera->setWhiteBalance(camera->getImagerSettings().hRes / 2 & 0xFFFFFFFE,
 							camera->getImagerSettings().vRes / 2 & 0xFFFFFFFE);	//Sample from middle but make sure position is a multiple of 2
 	if(ret == CAMERA_CLIPPED_ERROR)
@@ -321,7 +322,8 @@ void CamMainWindow::on_cmdWB_clicked()
 		sw->setText("Too dark. Increase exposure and try white balance again");
 		sw->setTimeout(3000);
 		sw->show();
-	}
+	}*/
+		whiteBalanceDialog *whiteBalWindow = new whiteBalanceDialog(NULL, camera);
 }
 
 void CamMainWindow::on_cmdIOSettings_clicked()

--- a/src/whitebalancedialog.cpp
+++ b/src/whitebalancedialog.cpp
@@ -25,11 +25,11 @@ whiteBalanceDialog::whiteBalanceDialog(QWidget *parent, Camera * cameraInst) :
 			appSettings.value("whiteBalance/customG", 1.0).toDouble(),
 			appSettings.value("whiteBalance/customB", 1.0).toDouble(),
 			"Custom");
-	addPreset(1.53, 1.00, 1.35, "8000k - Cloudy Sky");
-	addPreset(1.42, 1.00, 1.46, "6500k - Noon Sunlight");
-	addPreset(1.35, 1.00, 1.584,"5600k - Average Daylight");
-	addPreset(1.30, 1.00, 1.61, "5250k - Electronic Flash");
-	addPreset(1.22, 1.00, 1.74, "4600k - Flourescent");
+	addPreset(1.53, 1.00, 1.35, "8000K(Cloudy Sky)");
+	addPreset(1.42, 1.00, 1.46, "6500K(Noon Daylight)");
+	addPreset(1.35, 1.00, 1.584,"5600K(Avg Daylight)");
+	addPreset(1.30, 1.00, 1.61, "5250K(Flash)");
+	addPreset(1.22, 1.00, 1.74, "4600K(Flourescent)");
 	windowInitComplete = true;
 	ui->comboWB->setCurrentIndex(camera->getWBIndex());
 }

--- a/src/whitebalancedialog.cpp
+++ b/src/whitebalancedialog.cpp
@@ -1,17 +1,54 @@
 #include "whitebalancedialog.h"
 #include "ui_whitebalancedialog.h"
+#include <QMessageBox>
 
 whiteBalanceDialog::whiteBalanceDialog(QWidget *parent, Camera * cameraInst) :
 	QDialog(parent),
 	ui(new Ui::whiteBalanceDialog)
 {
+	windowInitComplete = false;
 	ui->setupUi(this);
 	camera = cameraInst;
 	this->setWindowFlags(Qt::Dialog /*| Qt::WindowStaysOnTopHint*/ | Qt::FramelessWindowHint);
 	this->move(camera->ButtonsOnLeft? 0:600, 0);
+	connect(ui->cmdClose, SIGNAL(clicked(bool)), this, SLOT(close()));
+	sw = new StatusWindow;
+	windowInitComplete = true;
 }
 
 whiteBalanceDialog::~whiteBalanceDialog()
 {
 	delete ui;
+}
+
+void whiteBalanceDialog::on_comboWB_currentIndexChanged(int index)
+{
+    if(!windowInitComplete) return;
+
+}
+
+void whiteBalanceDialog::on_cmdSetCustomWB_clicked()
+{
+	QMessageBox::StandardButton reply;
+	reply = QMessageBox::question(this, "Set white balance?", "Will set white balance. Continue?", QMessageBox::Yes|QMessageBox::No);
+	if(QMessageBox::Yes != reply)
+		return;
+
+	Int32 ret = camera->setWhiteBalance(camera->getImagerSettings().hRes / 2 & 0xFFFFFFFE,
+								 camera->getImagerSettings().vRes / 2 & 0xFFFFFFFE);	//Sample from middle but make sure position is a multiple of 2
+	if(ret == CAMERA_CLIPPED_ERROR)
+	{
+		sw->setText("Clipping. Reduce exposure and try white balance again");
+		sw->setTimeout(3000);
+		sw->show();
+		return;
+	}
+	else if(ret == CAMERA_LOW_SIGNAL_ERROR)
+	{
+		sw->setText("Too dark. Increase exposure and try white balance again");
+		sw->setTimeout(3000);
+		sw->show();
+		return;
+	}
+	ui->comboWB->setCurrentIndex(0);
 }

--- a/src/whitebalancedialog.cpp
+++ b/src/whitebalancedialog.cpp
@@ -24,7 +24,7 @@ whiteBalanceDialog::whiteBalanceDialog(QWidget *parent, Camera * cameraInst) :
 	addPreset(appSettings.value("whiteBalance/customR", 1.0).toDouble(),
 			appSettings.value("whiteBalance/customG", 1.0).toDouble(),
 			appSettings.value("whiteBalance/customB", 1.0).toDouble(),
-			"Custom");//add preset for custom here
+			"Custom");
 	addPreset(1.53, 1.00, 1.35, "8000k - Cloudy Sky");
 	addPreset(1.42, 1.00, 1.46, "6500k - Noon Sunlight");
 	addPreset(1.35, 1.00, 1.584,"5600k - Average Daylight");
@@ -41,10 +41,10 @@ whiteBalanceDialog::~whiteBalanceDialog()
 
 void whiteBalanceDialog::addPreset(double r, double g, double b, QString s){
 	ui->comboWB->addItem(s);
-	qDebug() << "setCurrentIndex" << ui->comboWB->count()-1;
-	sceneWhiteBalPresets[ui->comboWB->count()-1][0] = r;
-	sceneWhiteBalPresets[ui->comboWB->count()-1][1] = g;
-	sceneWhiteBalPresets[ui->comboWB->count()-1][2] = b;
+	UInt8 workingPreset = ui->comboWB->count()-1;
+	sceneWhiteBalPresets[workingPreset][0] = r;
+	sceneWhiteBalPresets[workingPreset][1] = g;
+	sceneWhiteBalPresets[workingPreset][2] = b;
 }
 
 void whiteBalanceDialog::on_comboWB_currentIndexChanged(int index)

--- a/src/whitebalancedialog.cpp
+++ b/src/whitebalancedialog.cpp
@@ -17,7 +17,6 @@ whiteBalanceDialog::whiteBalanceDialog(QWidget *parent, Camera * cameraInst) :
 	camera = cameraInst;
 	this->setWindowFlags(Qt::Dialog /*| Qt::WindowStaysOnTopHint*/ | Qt::FramelessWindowHint);
 	this->move(camera->ButtonsOnLeft? 0:600, 0);
-	connect(ui->cmdClose, SIGNAL(clicked(bool)), this, SLOT(close()));
 	sw = new StatusWindow;
 
 	QSettings appSettings;
@@ -95,4 +94,10 @@ void whiteBalanceDialog::on_cmdSetCustomWB_clicked()
 	sceneWhiteBalPresets[0][0] = RED;
 	sceneWhiteBalPresets[0][1] = GREEN;
 	sceneWhiteBalPresets[0][2] = BLUE;
+}
+
+void whiteBalanceDialog::on_cmdClose_clicked()
+{
+	delete sw;
+	this->close();
 }

--- a/src/whitebalancedialog.cpp
+++ b/src/whitebalancedialog.cpp
@@ -19,11 +19,7 @@ whiteBalanceDialog::whiteBalanceDialog(QWidget *parent, Camera * cameraInst) :
 	this->move(camera->ButtonsOnLeft? 0:600, 0);
 	sw = new StatusWindow;
 
-	QSettings appSettings;
-	addPreset(appSettings.value("whiteBalance/customR", 1.0).toDouble(),
-			appSettings.value("whiteBalance/customG", 1.0).toDouble(),
-			appSettings.value("whiteBalance/customB", 1.0).toDouble(),
-			"Custom");
+	addCustomPreset();
 	customWhiteBalOld[0] = sceneWhiteBalPresets[0][0];
 	customWhiteBalOld[1] = sceneWhiteBalPresets[0][1];
 	customWhiteBalOld[2] = sceneWhiteBalPresets[0][2];
@@ -47,6 +43,14 @@ void whiteBalanceDialog::addPreset(double r, double g, double b, QString s){
 	sceneWhiteBalPresets[workingPreset][0] = r;
 	sceneWhiteBalPresets[workingPreset][1] = g;
 	sceneWhiteBalPresets[workingPreset][2] = b;
+}
+
+void whiteBalanceDialog::addCustomPreset(){
+	QSettings appSettings;
+	addPreset(appSettings.value("whiteBalance/customR", 1.0).toDouble(),
+			appSettings.value("whiteBalance/customG", 1.0).toDouble(),
+			appSettings.value("whiteBalance/customB", 1.0).toDouble(),
+			"Custom");
 }
 
 void whiteBalanceDialog::on_comboWB_currentIndexChanged(int index)

--- a/src/whitebalancedialog.cpp
+++ b/src/whitebalancedialog.cpp
@@ -21,19 +21,21 @@ whiteBalanceDialog::whiteBalanceDialog(QWidget *parent, Camera * cameraInst) :
 	sw = new StatusWindow;
 	QSettings appSettings;	
 	
-	customWhiteBalOld[0] = sceneWhiteBalPresets[0][0];
-	customWhiteBalOld[1] = sceneWhiteBalPresets[0][1];
-	customWhiteBalOld[2] = sceneWhiteBalPresets[0][2];
-	
 	addPreset(1.53, 1.00, 1.35, "8000K(Cloudy Sky)");
 	addPreset(1.42, 1.00, 1.46, "6500K(Noon Daylight)");
 	addPreset(1.35, 1.00, 1.584,"5600K(Avg Daylight)");
 	addPreset(1.30, 1.00, 1.61, "5250K(Flash)");
 	addPreset(1.22, 1.00, 1.74, "4600K(Flourescent)");
 	
-	if(appSettings.value("whiteBalance/customR", 0.0).toDouble() != 0.0){//Only add Custom if the values have been set
+	if(appSettings.value("whiteBalance/customR", 0.0).toDouble() != 0.0){
+		//Only if custom values have been loaded, add "Custom" to the list and store old WB values
+		
 		addCustomPreset();
-	}
+		
+		customWhiteBalOld[0] = sceneWhiteBalPresets[COMBO_MAX_INDEX][0];
+		customWhiteBalOld[1] = sceneWhiteBalPresets[COMBO_MAX_INDEX][1];
+		customWhiteBalOld[2] = sceneWhiteBalPresets[COMBO_MAX_INDEX][2];
+	} else customWhiteBalOld[0] = -1.0;
 	
 	windowInitComplete = true;
 	ui->comboWB->setCurrentIndex(camera->getWBIndex());
@@ -73,7 +75,7 @@ void whiteBalanceDialog::on_comboWB_currentIndexChanged(int index)
 	appSettings.setValue("whiteBalance/currentR", RED);
 	appSettings.setValue("whiteBalance/currentG", GREEN);
 	appSettings.setValue("whiteBalance/currentB", BLUE);
-	//qDebug() <<" colors: " << RED << GREEN << BLUE;
+	qDebug() <<" colors: " << RED << GREEN << BLUE;
 	camera->setCCMatrix();
 }
 
@@ -115,7 +117,7 @@ void whiteBalanceDialog::on_cmdSetCustomWB_clicked()
 	sceneWhiteBalPresets[COMBO_MAX_INDEX][2] = BLUE;
 	
 	ui->comboWB->setCurrentIndex(COMBO_MAX_INDEX);
-	ui->cmdResetCustomWB->setEnabled(true);
+	if(customWhiteBalOld[0] > 0.0) ui->cmdResetCustomWB->setEnabled(true);
 	qDebug("COMBO_COUNT = %d", COMBO_MAX_INDEX);
 }
 
@@ -137,5 +139,6 @@ void whiteBalanceDialog::on_cmdResetCustomWB_clicked()
     appSettings.setValue("whiteBalance/currentB", BLUE);
     
     if(ui->comboWB->currentIndex() == COMBO_MAX_INDEX)	camera->setCCMatrix();
-    //qDebug() <<" colors: " << RED << GREEN << BLUE;
+    qDebug() <<" colors: " << RED << GREEN << BLUE;
+    qDebug()<<"sceneWhiteBalPresets: " <<customWhiteBalOld[0] << customWhiteBalOld[1] << customWhiteBalOld[2];
 }

--- a/src/whitebalancedialog.cpp
+++ b/src/whitebalancedialog.cpp
@@ -101,9 +101,6 @@ void whiteBalanceDialog::on_cmdSetCustomWB_clicked()
 		return;
 	}
 	
-	ui->comboWB->setCurrentIndex(0);
-	ui->cmdResetCustomWB->setEnabled(true);
-
 	camera->setCCMatrix();
 	
 	QSettings appSettings;
@@ -116,6 +113,10 @@ void whiteBalanceDialog::on_cmdSetCustomWB_clicked()
 	sceneWhiteBalPresets[COMBO_MAX_INDEX][0] = RED;
 	sceneWhiteBalPresets[COMBO_MAX_INDEX][1] = GREEN;
 	sceneWhiteBalPresets[COMBO_MAX_INDEX][2] = BLUE;
+	
+	ui->comboWB->setCurrentIndex(COMBO_MAX_INDEX);
+	ui->cmdResetCustomWB->setEnabled(true);
+	qDebug("COMBO_COUNT = %d", COMBO_MAX_INDEX);
 }
 
 void whiteBalanceDialog::on_cmdClose_clicked()
@@ -135,6 +136,6 @@ void whiteBalanceDialog::on_cmdResetCustomWB_clicked()
     appSettings.setValue("whiteBalance/currentG", GREEN);
     appSettings.setValue("whiteBalance/currentB", BLUE);
     
-    if(ui->comboWB->currentIndex() == 0)	camera->setCCMatrix();
+    if(ui->comboWB->currentIndex() == COMBO_MAX_INDEX)	camera->setCCMatrix();
     //qDebug() <<" colors: " << RED << GREEN << BLUE;
 }

--- a/src/whitebalancedialog.cpp
+++ b/src/whitebalancedialog.cpp
@@ -24,6 +24,9 @@ whiteBalanceDialog::whiteBalanceDialog(QWidget *parent, Camera * cameraInst) :
 			appSettings.value("whiteBalance/customG", 1.0).toDouble(),
 			appSettings.value("whiteBalance/customB", 1.0).toDouble(),
 			"Custom");
+	customWhiteBalOld[0] = sceneWhiteBalPresets[0][0];
+	customWhiteBalOld[1] = sceneWhiteBalPresets[0][1];
+	customWhiteBalOld[2] = sceneWhiteBalPresets[0][2];
 	addPreset(1.53, 1.00, 1.35, "8000K(Cloudy Sky)");
 	addPreset(1.42, 1.00, 1.46, "6500K(Noon Daylight)");
 	addPreset(1.35, 1.00, 1.584,"5600K(Avg Daylight)");
@@ -69,6 +72,7 @@ void whiteBalanceDialog::on_cmdSetCustomWB_clicked()
 		return;
 
 	ui->comboWB->setCurrentIndex(0);
+	ui->cmdResetCustomWB->setEnabled(true);
 
 	Int32 ret = camera->setWhiteBalance(camera->getImagerSettings().hRes / 2 & 0xFFFFFFFE,
 								 camera->getImagerSettings().vRes / 2 & 0xFFFFFFFE);	//Sample from middle but make sure position is a multiple of 2
@@ -100,4 +104,17 @@ void whiteBalanceDialog::on_cmdClose_clicked()
 {
 	delete sw;
 	this->close();
+}
+
+void whiteBalanceDialog::on_cmdResetCustomWB_clicked()
+{
+    RED   = sceneWhiteBalPresets[0][0] = customWhiteBalOld[0];
+    GREEN = sceneWhiteBalPresets[0][1] = customWhiteBalOld[1];
+    BLUE  = sceneWhiteBalPresets[0][2] = customWhiteBalOld[2];
+    QSettings appSettings;
+    appSettings.setValue("whiteBalance/currentR", RED);
+    appSettings.setValue("whiteBalance/currentG", GREEN);
+    appSettings.setValue("whiteBalance/currentB", BLUE);
+    if(ui->comboWB->currentIndex() == 0)	camera->setCCMatrix();
+    qDebug() <<" colors: " << RED << GREEN << BLUE;
 }

--- a/src/whitebalancedialog.cpp
+++ b/src/whitebalancedialog.cpp
@@ -1,6 +1,7 @@
 #include "whitebalancedialog.h"
 #include "ui_whitebalancedialog.h"
 #include <QMessageBox>
+#include <QSettings>
 
 whiteBalanceDialog::whiteBalanceDialog(QWidget *parent, Camera * cameraInst) :
 	QDialog(parent),
@@ -13,6 +14,7 @@ whiteBalanceDialog::whiteBalanceDialog(QWidget *parent, Camera * cameraInst) :
 	this->move(camera->ButtonsOnLeft? 0:600, 0);
 	connect(ui->cmdClose, SIGNAL(clicked(bool)), this, SLOT(close()));
 	sw = new StatusWindow;
+	ui->comboWB->setCurrentIndex(camera->getWBIndex());
 	windowInitComplete = true;
 }
 
@@ -23,8 +25,8 @@ whiteBalanceDialog::~whiteBalanceDialog()
 
 void whiteBalanceDialog::on_comboWB_currentIndexChanged(int index)
 {
-    if(!windowInitComplete) return;
-
+	if(!windowInitComplete) return;
+	camera->setWBIndex(index);
 }
 
 void whiteBalanceDialog::on_cmdSetCustomWB_clicked()

--- a/src/whitebalancedialog.cpp
+++ b/src/whitebalancedialog.cpp
@@ -65,6 +65,8 @@ void whiteBalanceDialog::on_cmdSetCustomWB_clicked()
 	if(QMessageBox::Yes != reply)
 		return;
 
+	ui->comboWB->setCurrentIndex(0);
+
 	Int32 ret = camera->setWhiteBalance(camera->getImagerSettings().hRes / 2 & 0xFFFFFFFE,
 								 camera->getImagerSettings().vRes / 2 & 0xFFFFFFFE);	//Sample from middle but make sure position is a multiple of 2
 	if(ret == CAMERA_CLIPPED_ERROR)
@@ -81,6 +83,12 @@ void whiteBalanceDialog::on_cmdSetCustomWB_clicked()
 		sw->show();
 		return;
 	}
-	ui->comboWB->setCurrentIndex(0);
 	camera->setCCMatrix();
+	QSettings appSettings;
+	appSettings.setValue("whiteBalance/customR", RED);
+	appSettings.setValue("whiteBalance/customG", GREEN);
+	appSettings.setValue("whiteBalance/customB", BLUE);
+	sceneWhiteBalPresets[0][0] = RED;
+	sceneWhiteBalPresets[0][1] = GREEN;
+	sceneWhiteBalPresets[0][2] = BLUE;
 }

--- a/src/whitebalancedialog.cpp
+++ b/src/whitebalancedialog.cpp
@@ -6,6 +6,9 @@ whiteBalanceDialog::whiteBalanceDialog(QWidget *parent, Camera * cameraInst) :
 	ui(new Ui::whiteBalanceDialog)
 {
 	ui->setupUi(this);
+	camera = cameraInst;
+	this->setWindowFlags(Qt::Dialog /*| Qt::WindowStaysOnTopHint*/ | Qt::FramelessWindowHint);
+	this->move(camera->ButtonsOnLeft? 0:600, 0);
 }
 
 whiteBalanceDialog::~whiteBalanceDialog()

--- a/src/whitebalancedialog.cpp
+++ b/src/whitebalancedialog.cpp
@@ -24,6 +24,9 @@ whiteBalanceDialog::whiteBalanceDialog(QWidget *parent, Camera * cameraInst) :
 	addPreset(1.53, 1.00, 1.35, "8000K(Cloudy Sky)");
 	addPreset(1.42, 1.00, 1.46, "6500K(Noon Daylight)");
 	addPreset(1.35, 1.00, 1.584,"5600K(Avg Daylight)");
+	/* Since "Avg Daylight" is chosen by default if this is the user's first time entering the WB dialog,
+	these the default values set near the end of Camera::init() on boot should match up with this,
+	or else the white balance will change from the original values to this upon opening the dialog. */
 	addPreset(1.30, 1.00, 1.61, "5250K(Flash)");
 	addPreset(1.22, 1.00, 1.74, "4600K(Flourescent)");
 	
@@ -35,7 +38,7 @@ whiteBalanceDialog::whiteBalanceDialog(QWidget *parent, Camera * cameraInst) :
 		customWhiteBalOld[0] = sceneWhiteBalPresets[COMBO_MAX_INDEX][0];
 		customWhiteBalOld[1] = sceneWhiteBalPresets[COMBO_MAX_INDEX][1];
 		customWhiteBalOld[2] = sceneWhiteBalPresets[COMBO_MAX_INDEX][2];
-	} else customWhiteBalOld[0] = -1.0;
+	} else customWhiteBalOld[0] = -1.0;// so that on_cmdSetCustomWB_clicked() knows not to enable the "Reset Custom WB" button
 	
 	windowInitComplete = true;
 	ui->comboWB->setCurrentIndex(camera->getWBIndex());
@@ -75,7 +78,7 @@ void whiteBalanceDialog::on_comboWB_currentIndexChanged(int index)
 	appSettings.setValue("whiteBalance/currentR", RED);
 	appSettings.setValue("whiteBalance/currentG", GREEN);
 	appSettings.setValue("whiteBalance/currentB", BLUE);
-	qDebug() <<" colors: " << RED << GREEN << BLUE;
+	//qDebug() <<" colors: " << RED << GREEN << BLUE;
 	camera->setCCMatrix();
 }
 
@@ -107,7 +110,7 @@ void whiteBalanceDialog::on_cmdSetCustomWB_clicked()
 	
 	QSettings appSettings;
 	if(appSettings.value("whiteBalance/customR", 0.0).toDouble() == 0.0)
-		ui->comboWB->addItem("Custom"); //Only add "Custom" if the values have not been set
+		ui->comboWB->addItem("Custom"); //Only add "Custom" if the values have not already been set
 	appSettings.setValue("whiteBalance/customR", RED);
 	appSettings.setValue("whiteBalance/customG", GREEN);
 	appSettings.setValue("whiteBalance/customB", BLUE);
@@ -118,7 +121,7 @@ void whiteBalanceDialog::on_cmdSetCustomWB_clicked()
 	
 	ui->comboWB->setCurrentIndex(COMBO_MAX_INDEX);
 	if(customWhiteBalOld[0] > 0.0) ui->cmdResetCustomWB->setEnabled(true);
-	qDebug("COMBO_COUNT = %d", COMBO_MAX_INDEX);
+	//qDebug("COMBO_COUNT = %d", COMBO_MAX_INDEX);
 }
 
 void whiteBalanceDialog::on_cmdClose_clicked()
@@ -139,6 +142,6 @@ void whiteBalanceDialog::on_cmdResetCustomWB_clicked()
     appSettings.setValue("whiteBalance/currentB", BLUE);
     
     if(ui->comboWB->currentIndex() == COMBO_MAX_INDEX)	camera->setCCMatrix();
-    qDebug() <<" colors: " << RED << GREEN << BLUE;
-    qDebug()<<"sceneWhiteBalPresets: " <<customWhiteBalOld[0] << customWhiteBalOld[1] << customWhiteBalOld[2];
+    //qDebug() <<" colors: " << RED << GREEN << BLUE;
+    //qDebug()<<"sceneWhiteBalPresets: " <<customWhiteBalOld[0] << customWhiteBalOld[1] << customWhiteBalOld[2];
 }

--- a/src/whitebalancedialog.cpp
+++ b/src/whitebalancedialog.cpp
@@ -19,7 +19,7 @@ whiteBalanceDialog::whiteBalanceDialog(QWidget *parent, Camera * cameraInst) :
 	this->move(camera->ButtonsOnLeft? 0:600, 0);
 	sw = new StatusWindow;
 
-	addCustomPreset();
+	QSettings appSettings;	
 	customWhiteBalOld[0] = sceneWhiteBalPresets[0][0];
 	customWhiteBalOld[1] = sceneWhiteBalPresets[0][1];
 	customWhiteBalOld[2] = sceneWhiteBalPresets[0][2];
@@ -28,6 +28,9 @@ whiteBalanceDialog::whiteBalanceDialog(QWidget *parent, Camera * cameraInst) :
 	addPreset(1.35, 1.00, 1.584,"5600K(Avg Daylight)");
 	addPreset(1.30, 1.00, 1.61, "5250K(Flash)");
 	addPreset(1.22, 1.00, 1.74, "4600K(Flourescent)");
+	if(appSettings.value("whiteBalance/customR", 0.0).toDouble() != 0.0){//Only add Custom if the values have been set
+		addCustomPreset();
+	}
 	windowInitComplete = true;
 	ui->comboWB->setCurrentIndex(camera->getWBIndex());
 }
@@ -56,11 +59,17 @@ void whiteBalanceDialog::addCustomPreset(){
 void whiteBalanceDialog::on_comboWB_currentIndexChanged(int index)
 {
 	if(!windowInitComplete) return;
+	QSettings appSettings;
+	/*
+	if(appSettings.value("whiteBalance/customR", 0.0).toDouble() == 0.0){
+		//if custom NOT set, increment index to assign correct values
+		index++;
+	qDebug("custom not set.  index incremented.");}*/
+	qDebug("index is decremented to %d", index);
 	camera->setWBIndex(index);
 	RED =   sceneWhiteBalPresets[index][0];
 	GREEN = sceneWhiteBalPresets[index][1];
 	BLUE =  sceneWhiteBalPresets[index][2];
-	QSettings appSettings;
 	appSettings.setValue("whiteBalance/currentR", RED);
 	appSettings.setValue("whiteBalance/currentG", GREEN);
 	appSettings.setValue("whiteBalance/currentB", BLUE);
@@ -96,12 +105,14 @@ void whiteBalanceDialog::on_cmdSetCustomWB_clicked()
 	}
 	camera->setCCMatrix();
 	QSettings appSettings;
+	if(appSettings.value("whiteBalance/customR", 0.0).toDouble() == 0.0)
+		ui->comboWB->addItem("Custom"); //Only add "Custom" if the values have not been set
 	appSettings.setValue("whiteBalance/customR", RED);
 	appSettings.setValue("whiteBalance/customG", GREEN);
 	appSettings.setValue("whiteBalance/customB", BLUE);
-	sceneWhiteBalPresets[0][0] = RED;
-	sceneWhiteBalPresets[0][1] = GREEN;
-	sceneWhiteBalPresets[0][2] = BLUE;
+	sceneWhiteBalPresets[ui->comboWB->count()-1][0] = RED;
+	sceneWhiteBalPresets[ui->comboWB->count()-1][1] = GREEN;
+	sceneWhiteBalPresets[ui->comboWB->count()-1][2] = BLUE;
 }
 
 void whiteBalanceDialog::on_cmdClose_clicked()
@@ -112,9 +123,9 @@ void whiteBalanceDialog::on_cmdClose_clicked()
 
 void whiteBalanceDialog::on_cmdResetCustomWB_clicked()
 {
-    RED   = sceneWhiteBalPresets[0][0] = customWhiteBalOld[0];
-    GREEN = sceneWhiteBalPresets[0][1] = customWhiteBalOld[1];
-    BLUE  = sceneWhiteBalPresets[0][2] = customWhiteBalOld[2];
+    RED   = sceneWhiteBalPresets[ui->comboWB->count()-1][0] = customWhiteBalOld[0];
+    GREEN = sceneWhiteBalPresets[ui->comboWB->count()-1][1] = customWhiteBalOld[1];
+    BLUE  = sceneWhiteBalPresets[ui->comboWB->count()-1][2] = customWhiteBalOld[2];
     QSettings appSettings;
     appSettings.setValue("whiteBalance/currentR", RED);
     appSettings.setValue("whiteBalance/currentG", GREEN);

--- a/src/whitebalancedialog.cpp
+++ b/src/whitebalancedialog.cpp
@@ -84,9 +84,6 @@ void whiteBalanceDialog::on_cmdSetCustomWB_clicked()
 	if(QMessageBox::Yes != reply)
 		return;
 
-	ui->comboWB->setCurrentIndex(0);
-	ui->cmdResetCustomWB->setEnabled(true);
-
 	Int32 ret = camera->setWhiteBalance(camera->getImagerSettings().hRes / 2 & 0xFFFFFFFE,
 								 camera->getImagerSettings().vRes / 2 & 0xFFFFFFFE);	//Sample from middle but make sure position is a multiple of 2
 	if(ret == CAMERA_CLIPPED_ERROR)
@@ -104,6 +101,9 @@ void whiteBalanceDialog::on_cmdSetCustomWB_clicked()
 		return;
 	}
 	
+	ui->comboWB->setCurrentIndex(0);
+	ui->cmdResetCustomWB->setEnabled(true);
+
 	camera->setCCMatrix();
 	
 	QSettings appSettings;

--- a/src/whitebalancedialog.cpp
+++ b/src/whitebalancedialog.cpp
@@ -1,7 +1,7 @@
 #include "whitebalancedialog.h"
 #include "ui_whitebalancedialog.h"
 
-whiteBalanceDialog::whiteBalanceDialog(QWidget *parent) :
+whiteBalanceDialog::whiteBalanceDialog(QWidget *parent, Camera * cameraInst) :
 	QDialog(parent),
 	ui(new Ui::whiteBalanceDialog)
 {

--- a/src/whitebalancedialog.cpp
+++ b/src/whitebalancedialog.cpp
@@ -1,0 +1,14 @@
+#include "whitebalancedialog.h"
+#include "ui_whitebalancedialog.h"
+
+whiteBalanceDialog::whiteBalanceDialog(QWidget *parent) :
+	QDialog(parent),
+	ui(new Ui::whiteBalanceDialog)
+{
+	ui->setupUi(this);
+}
+
+whiteBalanceDialog::~whiteBalanceDialog()
+{
+	delete ui;
+}

--- a/src/whitebalancedialog.cpp
+++ b/src/whitebalancedialog.cpp
@@ -54,6 +54,10 @@ void whiteBalanceDialog::on_comboWB_currentIndexChanged(int index)
 	RED =   sceneWhiteBalPresets[index][0];
 	GREEN = sceneWhiteBalPresets[index][1];
 	BLUE =  sceneWhiteBalPresets[index][2];
+	QSettings appSettings;
+	appSettings.setValue("whiteBalance/currentR", RED);
+	appSettings.setValue("whiteBalance/currentG", GREEN);
+	appSettings.setValue("whiteBalance/currentB", BLUE);
 	qDebug() <<" colors: " << RED << GREEN << BLUE;
 	camera->setCCMatrix();
 }

--- a/src/whitebalancedialog.h
+++ b/src/whitebalancedialog.h
@@ -27,6 +27,8 @@ private:
 	Camera * camera;
 	bool windowInitComplete;
 	StatusWindow * sw;
+	double sceneWhiteBalPresets[6][3];
+	void addPreset(double r, double b, double g, QString s);
 };
 
 #endif // WHITEBALANCEDIALOG_H

--- a/src/whitebalancedialog.h
+++ b/src/whitebalancedialog.h
@@ -3,6 +3,7 @@
 
 #include <QDialog>
 #include "camera.h"
+#include "statuswindow.h"
 
 namespace Ui {
 class whiteBalanceDialog;
@@ -16,9 +17,16 @@ public:
 	explicit whiteBalanceDialog(QWidget *parent = 0, Camera * cameraInst = NULL);
 	~whiteBalanceDialog();
 
+private slots:
+	void on_comboWB_currentIndexChanged(int index);
+
+	void on_cmdSetCustomWB_clicked();
+
 private:
 	Ui::whiteBalanceDialog *ui;
 	Camera * camera;
+	bool windowInitComplete;
+	StatusWindow * sw;
 };
 
 #endif // WHITEBALANCEDIALOG_H

--- a/src/whitebalancedialog.h
+++ b/src/whitebalancedialog.h
@@ -34,6 +34,7 @@ private:
 	double sceneWhiteBalPresets[6][3];
 	double customWhiteBalOld[3] = {1.0, 1.0, 1.0};
 	void addPreset(double r, double b, double g, QString s);
+	void addCustomPreset();
 };
 
 #endif // WHITEBALANCEDIALOG_H

--- a/src/whitebalancedialog.h
+++ b/src/whitebalancedialog.h
@@ -24,12 +24,15 @@ private slots:
 
 	void on_cmdClose_clicked();
 	
+	void on_cmdResetCustomWB_clicked();
+	
 private:
 	Ui::whiteBalanceDialog *ui;
 	Camera * camera;
 	bool windowInitComplete;
 	StatusWindow * sw;
 	double sceneWhiteBalPresets[6][3];
+	double customWhiteBalOld[3] = {1.0, 1.0, 1.0};
 	void addPreset(double r, double b, double g, QString s);
 };
 

--- a/src/whitebalancedialog.h
+++ b/src/whitebalancedialog.h
@@ -1,0 +1,22 @@
+#ifndef WHITEBALANCEDIALOG_H
+#define WHITEBALANCEDIALOG_H
+
+#include <QDialog>
+
+namespace Ui {
+class whiteBalanceDialog;
+}
+
+class whiteBalanceDialog : public QDialog
+{
+	Q_OBJECT
+
+public:
+	explicit whiteBalanceDialog(QWidget *parent = 0);
+	~whiteBalanceDialog();
+
+private:
+	Ui::whiteBalanceDialog *ui;
+};
+
+#endif // WHITEBALANCEDIALOG_H

--- a/src/whitebalancedialog.h
+++ b/src/whitebalancedialog.h
@@ -18,6 +18,7 @@ public:
 
 private:
 	Ui::whiteBalanceDialog *ui;
+	Camera * camera;
 };
 
 #endif // WHITEBALANCEDIALOG_H

--- a/src/whitebalancedialog.h
+++ b/src/whitebalancedialog.h
@@ -2,6 +2,7 @@
 #define WHITEBALANCEDIALOG_H
 
 #include <QDialog>
+#include "camera.h"
 
 namespace Ui {
 class whiteBalanceDialog;
@@ -12,7 +13,7 @@ class whiteBalanceDialog : public QDialog
 	Q_OBJECT
 
 public:
-	explicit whiteBalanceDialog(QWidget *parent = 0);
+	explicit whiteBalanceDialog(QWidget *parent = 0, Camera * cameraInst = NULL);
 	~whiteBalanceDialog();
 
 private:

--- a/src/whitebalancedialog.h
+++ b/src/whitebalancedialog.h
@@ -22,6 +22,8 @@ private slots:
 
 	void on_cmdSetCustomWB_clicked();
 
+	void on_cmdClose_clicked();
+	
 private:
 	Ui::whiteBalanceDialog *ui;
 	Camera * camera;

--- a/src/whitebalancedialog.ui
+++ b/src/whitebalancedialog.ui
@@ -16,11 +16,16 @@
   <widget class="QPushButton" name="cmdClose">
    <property name="geometry">
     <rect>
-     <x>25</x>
-     <y>115</y>
+     <x>85</x>
+     <y>415</y>
      <width>116</width>
-     <height>25</height>
+     <height>66</height>
     </rect>
+   </property>
+   <property name="font">
+    <font>
+     <pointsize>19</pointsize>
+    </font>
    </property>
    <property name="text">
     <string>Close</string>
@@ -29,11 +34,16 @@
   <widget class="QPushButton" name="cmdSetCustomWB">
    <property name="geometry">
     <rect>
-     <x>25</x>
-     <y>60</y>
-     <width>116</width>
-     <height>50</height>
+     <x>10</x>
+     <y>15</y>
+     <width>181</width>
+     <height>111</height>
     </rect>
+   </property>
+   <property name="font">
+    <font>
+     <pointsize>19</pointsize>
+    </font>
    </property>
    <property name="text">
     <string>Set Custom
@@ -43,10 +53,10 @@ White Balance</string>
   <widget class="QComboBox" name="comboWB">
    <property name="geometry">
     <rect>
-     <x>15</x>
-     <y>15</y>
-     <width>171</width>
-     <height>41</height>
+     <x>10</x>
+     <y>140</y>
+     <width>181</width>
+     <height>51</height>
     </rect>
    </property>
    <property name="font">

--- a/src/whitebalancedialog.ui
+++ b/src/whitebalancedialog.ui
@@ -53,15 +53,15 @@ White Balance</string>
   <widget class="QComboBox" name="comboWB">
    <property name="geometry">
     <rect>
-     <x>10</x>
+     <x>0</x>
      <y>140</y>
-     <width>181</width>
+     <width>201</width>
      <height>51</height>
     </rect>
    </property>
    <property name="font">
     <font>
-     <pointsize>16</pointsize>
+     <pointsize>15</pointsize>
      <weight>75</weight>
      <italic>true</italic>
      <bold>true</bold>

--- a/src/whitebalancedialog.ui
+++ b/src/whitebalancedialog.ui
@@ -53,15 +53,15 @@ White Balance</string>
   <widget class="QComboBox" name="comboWB">
    <property name="geometry">
     <rect>
-     <x>0</x>
+     <x>10</x>
      <y>195</y>
-     <width>201</width>
+     <width>181</width>
      <height>51</height>
     </rect>
    </property>
    <property name="font">
     <font>
-     <pointsize>15</pointsize>
+     <pointsize>13</pointsize>
      <weight>75</weight>
      <italic>true</italic>
      <bold>true</bold>

--- a/src/whitebalancedialog.ui
+++ b/src/whitebalancedialog.ui
@@ -54,7 +54,7 @@ White Balance</string>
    <property name="geometry">
     <rect>
      <x>0</x>
-     <y>140</y>
+     <y>195</y>
      <width>201</width>
      <height>51</height>
     </rect>
@@ -66,6 +66,25 @@ White Balance</string>
      <italic>true</italic>
      <bold>true</bold>
     </font>
+   </property>
+  </widget>
+  <widget class="QLabel" name="label">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>145</y>
+     <width>181</width>
+     <height>51</height>
+    </rect>
+   </property>
+   <property name="font">
+    <font>
+     <pointsize>19</pointsize>
+    </font>
+   </property>
+   <property name="text">
+    <string>Selected
+White Balance:</string>
    </property>
   </widget>
  </widget>

--- a/src/whitebalancedialog.ui
+++ b/src/whitebalancedialog.ui
@@ -26,7 +26,7 @@
     <string>Close</string>
    </property>
   </widget>
-  <widget class="QPushButton" name="pushButton">
+  <widget class="QPushButton" name="cmdSetCustomWB">
    <property name="geometry">
     <rect>
      <x>25</x>

--- a/src/whitebalancedialog.ui
+++ b/src/whitebalancedialog.ui
@@ -1,0 +1,18 @@
+<ui version="4.0">
+ <class>whiteBalanceDialog</class>
+ <widget class="QDialog" name="whiteBalanceDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/whitebalancedialog.ui
+++ b/src/whitebalancedialog.ui
@@ -57,36 +57,6 @@ White Balance</string>
      <bold>true</bold>
     </font>
    </property>
-   <item>
-    <property name="text">
-     <string>Custom</string>
-    </property>
-   </item>
-   <item>
-    <property name="text">
-     <string>Cloudy Sky</string>
-    </property>
-   </item>
-   <item>
-    <property name="text">
-     <string>Noon Sunlight</string>
-    </property>
-   </item>
-   <item>
-    <property name="text">
-     <string>Electronic Flash</string>
-    </property>
-   </item>
-   <item>
-    <property name="text">
-     <string>Flourescent</string>
-    </property>
-   </item>
-   <item>
-    <property name="text">
-     <string>Domesetic Lighting</string>
-    </property>
-   </item>
   </widget>
  </widget>
  <resources/>

--- a/src/whitebalancedialog.ui
+++ b/src/whitebalancedialog.ui
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>whiteBalanceDialog</class>
  <widget class="QDialog" name="whiteBalanceDialog">
@@ -6,12 +7,87 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>300</height>
+    <height>101</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Dialog</string>
   </property>
+  <widget class="QPushButton" name="cmdClose">
+   <property name="geometry">
+    <rect>
+     <x>225</x>
+     <y>65</y>
+     <width>116</width>
+     <height>25</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Close</string>
+   </property>
+  </widget>
+  <widget class="QPushButton" name="pushButton">
+   <property name="geometry">
+    <rect>
+     <x>225</x>
+     <y>10</y>
+     <width>116</width>
+     <height>50</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Set Custom
+White Balance</string>
+   </property>
+  </widget>
+  <widget class="QComboBox" name="comboWB">
+   <property name="geometry">
+    <rect>
+     <x>15</x>
+     <y>15</y>
+     <width>171</width>
+     <height>41</height>
+    </rect>
+   </property>
+   <property name="font">
+    <font>
+     <pointsize>16</pointsize>
+     <weight>75</weight>
+     <italic>true</italic>
+     <bold>true</bold>
+    </font>
+   </property>
+   <item>
+    <property name="text">
+     <string>Custom</string>
+    </property>
+   </item>
+   <item>
+    <property name="text">
+     <string>Cloudy Sky</string>
+    </property>
+   </item>
+   <item>
+    <property name="text">
+     <string>Noon Sunlight</string>
+    </property>
+   </item>
+   <item>
+    <property name="text">
+     <string>Electronic Flash</string>
+    </property>
+   </item>
+   <item>
+    <property name="text">
+     <string>Flourescent</string>
+    </property>
+   </item>
+   <item>
+    <property name="text">
+     <string>Domesetic Lighting</string>
+    </property>
+   </item>
+  </widget>
  </widget>
  <resources/>
  <connections/>

--- a/src/whitebalancedialog.ui
+++ b/src/whitebalancedialog.ui
@@ -87,6 +87,28 @@ White Balance</string>
 White Balance:</string>
    </property>
   </widget>
+  <widget class="QPushButton" name="cmdResetCustomWB">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>305</y>
+     <width>181</width>
+     <height>76</height>
+    </rect>
+   </property>
+   <property name="font">
+    <font>
+     <pointsize>19</pointsize>
+    </font>
+   </property>
+   <property name="text">
+    <string>Reset Custom
+White Balance</string>
+   </property>
+  </widget>
  </widget>
  <resources/>
  <connections/>

--- a/src/whitebalancedialog.ui
+++ b/src/whitebalancedialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
-    <height>101</height>
+    <width>200</width>
+    <height>480</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -16,8 +16,8 @@
   <widget class="QPushButton" name="cmdClose">
    <property name="geometry">
     <rect>
-     <x>225</x>
-     <y>65</y>
+     <x>25</x>
+     <y>115</y>
      <width>116</width>
      <height>25</height>
     </rect>
@@ -29,8 +29,8 @@
   <widget class="QPushButton" name="pushButton">
    <property name="geometry">
     <rect>
-     <x>225</x>
-     <y>10</y>
+     <x>25</x>
+     <y>60</y>
      <width>116</width>
      <height>50</height>
     </rect>


### PR DESCRIPTION
Add a white balance dialog where the user can either set a custom white balance, reset custom WB back to what it was when opening the dialog, or choose from a set of 5 white balance presets.
The presets currently available are:
8000k - Cloudy Sky
6500k - Noon Sunlight
5600k - Average Daylight
5250k - Electronic Flash
4500k - Flourescent