### PR TITLE
Filesize warning changes

### DIFF
--- a/src/playbackwindow.cpp
+++ b/src/playbackwindow.cpp
@@ -172,9 +172,15 @@ void playbackWindow::on_cmdSave_clicked()
 			qDebug("Estimated file size: %llu", estimatedSize);
 			qDebug("===================================");
 
-			if (estimatedSize > (statvfsBuf.f_bsize * (uint64_t)statvfsBuf.f_bfree) || estimatedSize > 4294967296) {
+			if (estimatedSize > 4294967296) {
 				QMessageBox::StandardButton reply;
-				reply = QMessageBox::question(this, "Estimated file size too large", "Estimated file size is larger than room on media/4GB. Attempt to save?", QMessageBox::Yes|QMessageBox::No);
+				reply = QMessageBox::question(this, "File size over 4GB", "Estimated file size is larger than 4GB, which FAT32 partitions will not accept. Attempt to save?", QMessageBox::Yes|QMessageBox::No);
+				if(QMessageBox::Yes != reply)
+					return;
+			}
+			if (estimatedSize > (statvfsBuf.f_bsize * (uint64_t)statvfsBuf.f_bfree)) {
+				QMessageBox::StandardButton reply;
+				reply = QMessageBox::question(this, "Estimated file size too large", "Estimated file size is larger than free space on media. Attempt to save?", QMessageBox::Yes|QMessageBox::No);
 				if(QMessageBox::Yes != reply)
 					return;
 			}

--- a/src/playbackwindow.cpp
+++ b/src/playbackwindow.cpp
@@ -178,7 +178,7 @@ void playbackWindow::on_cmdSave_clicked()
 			
 			if (estimatedSize > 4294967296 && fileSystemInfoBuf.f_type == 0x4d44) {//If file size is over 4GB and file system is FAT32
 				QMessageBox::StandardButton reply;
-				reply = QMessageBox::question(this, "File size over 4GB", "Estimated file size is larger than 4GB, which FAT32 partitions will not accept. Attempt to save?", QMessageBox::Yes|QMessageBox::No);
+				reply = QMessageBox::question(this, "File size over 4GB", "Estimated file size is larger than the 4GB limit for the the filesystem.\nAttempt to save anyway?", QMessageBox::Yes|QMessageBox::No);
 				if(QMessageBox::Yes != reply)
 					return;
 			}


### PR DESCRIPTION
1. Make 4+GB file warning FAT32-only.
2. Use a different message depending on which or both of the limits are exceeded - 4GB file size or free space on drive.
3. Reword the titles and text for the messageboxes.
4. Change the messagebox text icons from question type to warning type so that the sign beside the text will be a caution sign instead of a question mark.