### PR TITLE
Fix: Crash when storage full

### DIFF
--- a/src/playbackwindow.cpp
+++ b/src/playbackwindow.cpp
@@ -30,7 +30,7 @@
 #include <QMessageBox>
 #include <QSettings>
 
-#define MIN_FREE_SPACE 10000000
+#define MIN_FREE_SPACE 20000000
 
 playbackWindow::playbackWindow(QWidget *parent, Camera * cameraInst, bool autosave) :
 	QWidget(parent),

--- a/src/playbackwindow.cpp
+++ b/src/playbackwindow.cpp
@@ -181,6 +181,12 @@ void playbackWindow::on_cmdSave_clicked()
 			bool fileOverMaxSize = (estimatedSize > 4294967296 && fileSystemInfoBuf.f_type == 0x4d44);//If file size is over 4GB and file system is FAT32
 			insufficientFreeSpace_estimate = (estimatedSize > (statvfsBuf.f_bsize * (uint64_t)statvfsBuf.f_bfree));
 			
+			//If amount of free space is below both 10MB and below the estimated size of the video, do not allow the save to start
+			if(insufficientFreeSpace_estimate && MIN_FREE_SPACE > (statvfsBuf.f_bsize * (uint64_t)statvfsBuf.f_bfree)){
+				QMessageBox::warning(this, "Warning - Insufficient free space", "Cannot save a video because of insufficient free space", QMessageBox::Ok);
+				return;
+			}
+			
 			if (fileOverMaxSize && !insufficientFreeSpace_estimate) {//If file size is over 4GB and file system is FAT32
 				QMessageBox::StandardButton reply;
 				reply = QMessageBox::warning(this, "Warning - File size over limit", "Estimated file size is larger than the 4GB limit for the the filesystem.\nAttempt to save anyway?", QMessageBox::Yes|QMessageBox::No);

--- a/src/playbackwindow.cpp
+++ b/src/playbackwindow.cpp
@@ -368,8 +368,13 @@ void playbackWindow::checkForSaveDone()
 		struct statvfs statvfsBuf;
 		statvfs(camera->recorder->fileDirectory, &statvfsBuf);
 		qDebug("Free space: %llu  (%lu * %lu)", statvfsBuf.f_bsize * (uint64_t)statvfsBuf.f_bfree, statvfsBuf.f_bsize, statvfsBuf.f_bfree);
+		
+		/*Abort the save if insufficient free space,
+		but not if the save has already been aborted,
+		or if the save button is not enabled(unsafe to abort at that time)(except if save mode is RAW)*/
+		QSettings appSettings;
 		bool insufficientFreeSpace = (MIN_FREE_SPACE > statvfsBuf.f_bsize * (uint64_t)statvfsBuf.f_bfree);
-		if(insufficientFreeSpace && !saveAborted) on_cmdSave_clicked();//Abort the save if insufficient free space
+		if(insufficientFreeSpace && !saveAborted && (ui->cmdSave->isEnabled() || appSettings.value("recorder/saveFormat", 0).toUInt() != SAVE_MODE_H264)) on_cmdSave_clicked();
 		
 		/* Prevent the user from pressing the abort/save button just after the last frame,
 		 * as that can make the camera try to save a 2nd video too soon, crashing the camapp.*/

--- a/src/playbackwindow.cpp
+++ b/src/playbackwindow.cpp
@@ -402,12 +402,6 @@ void playbackWindow::checkForSaveDone()
 			on_cmdSave_clicked();
 			sw->setText("Storage is now full; Aborting...");			
 		}
-			
-		
-		/* Prevent the user from pressing the abort/save button just after the last frame,
-		 * as that can make the camera try to save a 2nd video too soon, crashing the camapp.*/
-		if(camera->playFrame >= markOutFrame - 25)
-			ui->cmdSave->setEnabled(false);
 	}
 }
 

--- a/src/playbackwindow.cpp
+++ b/src/playbackwindow.cpp
@@ -140,7 +140,9 @@ void playbackWindow::on_cmdSave_clicked()
 		}
 
 		if (!statvfs(camera->recorder->fileDirectory, &statvfsBuf)) {
+			
 			qDebug("===================================");
+			
 			// calculated estimated size
 			estimatedSize = (markOutFrame - markInFrame + 1);
 			qDebug("Number of frames: %llu", estimatedSize);
@@ -175,6 +177,7 @@ void playbackWindow::on_cmdSave_clicked()
 
 			qDebug("Free space: %llu  (%lu * %lu)", statvfsBuf.f_bsize * (uint64_t)statvfsBuf.f_bfree, statvfsBuf.f_bsize, statvfsBuf.f_bfree);
 			qDebug("Estimated file size: %llu", estimatedSize);
+			
 			qDebug("===================================");
 
 			statfs(camera->recorder->fileDirectory, &fileSystemInfoBuf);
@@ -200,6 +203,7 @@ void playbackWindow::on_cmdSave_clicked()
 				if(QMessageBox::Yes != reply)
 					return;
 			}
+			
 			if (fileOverMaxSize && insufficientFreeSpace_estimate){
 				QMessageBox::StandardButton reply;
 				reply = QMessageBox::warning(this, "Warning - File size over limits", "Estimated file size is larger than free space on drive.\nEstimated file size is larger than the 4GB limit for the the filesystem.\nAttempt to save anyway?", QMessageBox::Yes|QMessageBox::No);
@@ -211,6 +215,7 @@ void playbackWindow::on_cmdSave_clicked()
 		//Check that the path exists
 		struct stat sb;
 		struct stat sbP;
+		
 		if (stat(camera->recorder->fileDirectory, &sb) == 0 && S_ISDIR(sb.st_mode) &&
 				stat(parentPath, &sbP) == 0 && sb.st_dev != sbP.st_dev)		//If location is directory and is a mount point (device ID of parent is different from device ID of path)
 		{
@@ -231,14 +236,14 @@ void playbackWindow::on_cmdSave_clicked()
 				msg.exec();
 				return;
 			}
-	    else if(RECORD_INSUFFICIENT_SPACE == ret)
-	    {
+			else if(RECORD_INSUFFICIENT_SPACE == ret)
+			{
 				if(camera->recorder->errorCallback)
 					(*camera->recorder->errorCallback)(camera->recorder->errorCallbackArg, "insufficient free space");
-		msg.setText("Selected device does not have sufficient free space.");
-		msg.exec();
-		return;
-	    }
+				msg.setText("Selected device does not have sufficient free space.");
+				msg.exec();
+				return;
+			}
 
 			ui->cmdSave->setText("Abort\nSave");
 			setControlEnable(false);
@@ -291,6 +296,7 @@ void playbackWindow::on_cmdSaveSettings_clicked()
 	saveSettingsWindow *w = new saveSettingsWindow(NULL, camera);
 	w->setAttribute(Qt::WA_DeleteOnClose);
 	w->show();
+	
 	settingsWindowIsOpen = true;
 	if(camera->ButtonsOnLeft) w->move(230, 0);
 	ui->cmdSaveSettings->setEnabled(false);

--- a/src/playbackwindow.cpp
+++ b/src/playbackwindow.cpp
@@ -42,6 +42,8 @@ playbackWindow::playbackWindow(QWidget *parent, Camera * cameraInst, bool autosa
 	camera = cameraInst;
 	autoSaveFlag = autosave;
 	this->move(camera->ButtonsOnLeft? 0:600, 0);
+	saveAborted = false;
+	
 
 	sw = new StatusWindow;
 
@@ -267,6 +269,8 @@ void playbackWindow::on_cmdSave_clicked()
 		camera->recorder->stop2();
 		ui->verticalSlider->removeLastRegionFromList();
 		ui->verticalSlider->setHighlightRegion(markInFrame, markOutFrame);
+		saveAborted = true;
+		//qDebug()<<"Aborting...";
 	}
 
 }
@@ -347,6 +351,7 @@ void playbackWindow::checkForSaveDone()
 		setControlEnable(true);
 		emit enableSaveSettingsButtons(true);
 		ui->cmdSave->setEnabled(true);
+		saveAborted = false;
 		updatePlayRateLabel(playbackRate);
 		ui->verticalSlider->setHighlightRegion(markInFrame, markOutFrame);
 
@@ -364,7 +369,7 @@ void playbackWindow::checkForSaveDone()
 		statvfs(camera->recorder->fileDirectory, &statvfsBuf);
 		qDebug("Free space: %llu  (%lu * %lu)", statvfsBuf.f_bsize * (uint64_t)statvfsBuf.f_bfree, statvfsBuf.f_bsize, statvfsBuf.f_bfree);
 		bool insufficientFreeSpace = (MIN_FREE_SPACE > statvfsBuf.f_bsize * (uint64_t)statvfsBuf.f_bfree);
-		if(insufficientFreeSpace) on_cmdSave_clicked();//Abort the save if insufficient free space
+		if(insufficientFreeSpace && !saveAborted) on_cmdSave_clicked();//Abort the save if insufficient free space
 		
 		/* Prevent the user from pressing the abort/save button just after the last frame,
 		 * as that can make the camera try to save a 2nd video too soon, crashing the camapp.*/

--- a/src/playbackwindow.cpp
+++ b/src/playbackwindow.cpp
@@ -150,7 +150,7 @@ void playbackWindow::on_cmdSave_clicked()
 			estimatedSize *= appSettings.value("camera/vRes", MAX_FRAME_SIZE_V).toInt();
 			qDebug("Resolution: %d x %d", appSettings.value("camera/hRes", MAX_FRAME_SIZE_H).toInt(), appSettings.value("camera/vRes", MAX_FRAME_SIZE_V).toInt());
 			// multiply by bits per pixel
-			switch(appSettings.value("recorder/saveFormat", 0).toUInt()) {
+			switch(getSaveFormat()) {
 			case SAVE_MODE_H264:
 				// the *1.2 part is fudge factor
 				estimatedSize = (uint64_t) ((double)estimatedSize * appSettings.value("recorder/bitsPerPixel", camera->recorder->bitsPerPixel).toDouble() * 1.2);
@@ -392,12 +392,11 @@ void playbackWindow::checkForSaveDone()
 		/*Abort the save if insufficient free space,
 		but not if the save has already been aborted,
 		or if the save button is not enabled(unsafe to abort at that time)(except if save mode is RAW)*/
-		QSettings appSettings;
 		bool insufficientFreeSpaceCurrent = (MIN_FREE_SPACE > statvfsBuf.f_bsize * (uint64_t)statvfsBuf.f_bfree);
 		if(insufficientFreeSpaceCurrent &&
 		   !saveAborted &&
 				(ui->cmdSave->isEnabled() ||
-				appSettings.value("recorder/saveFormat", 0).toUInt() != SAVE_MODE_H264)
+				getSaveFormat() != SAVE_MODE_H264)
 		   ) {
 			on_cmdSave_clicked();
 			sw->setText("Storage is now full; Aborting...");			
@@ -456,4 +455,9 @@ void playbackWindow::setControlEnable(bool en)
 void playbackWindow::on_cmdClose_clicked()
 {
     camera->videoHasBeenReviewed = true;
+}
+
+UInt32 playbackWindow::getSaveFormat(){
+	QSettings appSettings;
+	return appSettings.value("recorder/saveFormat", 0).toUInt();
 }

--- a/src/playbackwindow.cpp
+++ b/src/playbackwindow.cpp
@@ -369,17 +369,17 @@ void playbackWindow::checkForSaveDone()
 		statvfs(camera->recorder->fileDirectory, &statvfsBuf);
 		qDebug("Free space: %llu  (%lu * %lu)", statvfsBuf.f_bsize * (uint64_t)statvfsBuf.f_bfree, statvfsBuf.f_bsize, statvfsBuf.f_bfree);
 		
+		/* Prevent the user from pressing the abort/save button just after the last frame,
+		 * as that can make the camera try to save a 2nd video too soon, crashing the camapp.*/
+		if(camera->playFrame >= markOutFrame - 25)
+			ui->cmdSave->setEnabled(false);
+		
 		/*Abort the save if insufficient free space,
 		but not if the save has already been aborted,
 		or if the save button is not enabled(unsafe to abort at that time)(except if save mode is RAW)*/
 		QSettings appSettings;
 		bool insufficientFreeSpace = (MIN_FREE_SPACE > statvfsBuf.f_bsize * (uint64_t)statvfsBuf.f_bfree);
 		if(insufficientFreeSpace && !saveAborted && (ui->cmdSave->isEnabled() || appSettings.value("recorder/saveFormat", 0).toUInt() != SAVE_MODE_H264)) on_cmdSave_clicked();
-		
-		/* Prevent the user from pressing the abort/save button just after the last frame,
-		 * as that can make the camera try to save a 2nd video too soon, crashing the camapp.*/
-		if(camera->playFrame >= markOutFrame - 25)
-			ui->cmdSave->setEnabled(false);
 	}
 }
 

--- a/src/playbackwindow.cpp
+++ b/src/playbackwindow.cpp
@@ -282,6 +282,7 @@ void playbackWindow::on_cmdSave_clicked()
 		ui->verticalSlider->removeLastRegionFromList();
 		ui->verticalSlider->setHighlightRegion(markInFrame, markOutFrame);
 		saveAborted = true;
+		sw->setText("Aborting...");
 		//qDebug()<<"Aborting...";
 	}
 
@@ -396,7 +397,11 @@ void playbackWindow::checkForSaveDone()
 		   !saveAborted &&
 				(ui->cmdSave->isEnabled() ||
 				appSettings.value("recorder/saveFormat", 0).toUInt() != SAVE_MODE_H264)
-		   ) on_cmdSave_clicked();
+		   ) {
+			on_cmdSave_clicked();
+			sw->setText("Storage is now full; Aborting...");			
+		}
+			
 		
 		/* Prevent the user from pressing the abort/save button just after the last frame,
 		 * as that can make the camera try to save a 2nd video too soon, crashing the camapp.*/

--- a/src/playbackwindow.cpp
+++ b/src/playbackwindow.cpp
@@ -30,6 +30,7 @@
 #include <QMessageBox>
 #include <QSettings>
 
+#define MIN_FREE_SPACE 10000000
 
 playbackWindow::playbackWindow(QWidget *parent, Camera * cameraInst, bool autosave) :
 	QWidget(parent),
@@ -362,7 +363,7 @@ void playbackWindow::checkForSaveDone()
 		struct statvfs statvfsBuf;
 		statvfs(camera->recorder->fileDirectory, &statvfsBuf);
 		qDebug("Free space: %llu  (%lu * %lu)", statvfsBuf.f_bsize * (uint64_t)statvfsBuf.f_bfree, statvfsBuf.f_bsize, statvfsBuf.f_bfree);
-		bool insufficientFreeSpace = (10000000 > statvfsBuf.f_bsize * (uint64_t)statvfsBuf.f_bfree);
+		bool insufficientFreeSpace = (MIN_FREE_SPACE > statvfsBuf.f_bsize * (uint64_t)statvfsBuf.f_bfree);
 		if(insufficientFreeSpace) on_cmdSave_clicked();//Abort the save if insufficient free space
 		
 		/* Prevent the user from pressing the abort/save button just after the last frame,

--- a/src/playbackwindow.cpp
+++ b/src/playbackwindow.cpp
@@ -359,6 +359,12 @@ void playbackWindow::checkForSaveDone()
 		ui->lblFrameRate->setText(tmp);
 		setControlEnable(false);
 
+		struct statvfs statvfsBuf;
+		statvfs(camera->recorder->fileDirectory, &statvfsBuf);
+		qDebug("Free space: %llu  (%lu * %lu)", statvfsBuf.f_bsize * (uint64_t)statvfsBuf.f_bfree, statvfsBuf.f_bsize, statvfsBuf.f_bfree);
+		bool insufficientFreeSpace = (10000000 > statvfsBuf.f_bsize * (uint64_t)statvfsBuf.f_bfree);
+		if(insufficientFreeSpace) on_cmdSave_clicked();//Abort the save if insufficient free space
+		
 		/* Prevent the user from pressing the abort/save button just after the last frame,
 		 * as that can make the camera try to save a 2nd video too soon, crashing the camapp.*/
 		if(camera->playFrame >= markOutFrame - 25)

--- a/src/playbackwindow.cpp
+++ b/src/playbackwindow.cpp
@@ -262,7 +262,8 @@ void playbackWindow::on_cmdSave_clicked()
 
 			ui->verticalSlider->appendRegionToList();
 			ui->verticalSlider->setHighlightRegion(markOutFrame, markOutFrame);
-			//both arguments should be markout because a new rectangle will be drawn, and it should not overlap the one that was just appended
+			//both arguments should be markout because a new rectangle will be drawn,
+			//and it should not overlap the one that was just appended
 			emit enableSaveSettingsButtons(false);
 		}
 		else
@@ -391,7 +392,11 @@ void playbackWindow::checkForSaveDone()
 		or if the save button is not enabled(unsafe to abort at that time)(except if save mode is RAW)*/
 		QSettings appSettings;
 		bool insufficientFreeSpace_current = (MIN_FREE_SPACE > statvfsBuf.f_bsize * (uint64_t)statvfsBuf.f_bfree);
-		if(insufficientFreeSpace_current && !saveAborted && (ui->cmdSave->isEnabled() || appSettings.value("recorder/saveFormat", 0).toUInt() != SAVE_MODE_H264)) on_cmdSave_clicked();
+		if(insufficientFreeSpace_current &&
+		   !saveAborted &&
+				(ui->cmdSave->isEnabled() ||
+				appSettings.value("recorder/saveFormat", 0).toUInt() != SAVE_MODE_H264)
+		   ) on_cmdSave_clicked();
 		
 		/* Prevent the user from pressing the abort/save button just after the last frame,
 		 * as that can make the camera try to save a 2nd video too soon, crashing the camapp.*/
@@ -433,7 +438,9 @@ void playbackWindow::updatePlayRateLabel(Int32 playbackRate)
 
 void playbackWindow::setControlEnable(bool en)
 {
-	if(!settingsWindowIsOpen){//While settings window is open, don't let the user close the playback window or open another settings window.
+	//While settings window is open, don't let the user
+	//close the playback window or open another settings window.
+	if(!settingsWindowIsOpen){
 		ui->cmdClose->setEnabled(en);
 		ui->cmdSaveSettings->setEnabled(en);
 	}

--- a/src/playbackwindow.cpp
+++ b/src/playbackwindow.cpp
@@ -278,6 +278,7 @@ void playbackWindow::on_cmdSave_clicked()
 	else
 	{
 		//This block is executed when Abort is clicked
+		//or when save is automatically aborted due to full storage
 		camera->recorder->stop2();
 		ui->verticalSlider->removeLastRegionFromList();
 		ui->verticalSlider->setHighlightRegion(markInFrame, markOutFrame);

--- a/src/playbackwindow.cpp
+++ b/src/playbackwindow.cpp
@@ -182,29 +182,29 @@ void playbackWindow::on_cmdSave_clicked()
 
 			statfs(camera->recorder->fileDirectory, &fileSystemInfoBuf);
 			bool fileOverMaxSize = (estimatedSize > 4294967296 && fileSystemInfoBuf.f_type == 0x4d44);//If file size is over 4GB and file system is FAT32
-			insufficientFreeSpace_estimate = (estimatedSize > (statvfsBuf.f_bsize * (uint64_t)statvfsBuf.f_bfree));
+			insufficientFreeSpaceEstimate = (estimatedSize > (statvfsBuf.f_bsize * (uint64_t)statvfsBuf.f_bfree));
 			
 			//If amount of free space is below both 10MB and below the estimated size of the video, do not allow the save to start
-			if(insufficientFreeSpace_estimate && MIN_FREE_SPACE > (statvfsBuf.f_bsize * (uint64_t)statvfsBuf.f_bfree)){
+			if(insufficientFreeSpaceEstimate && MIN_FREE_SPACE > (statvfsBuf.f_bsize * (uint64_t)statvfsBuf.f_bfree)){
 				QMessageBox::warning(this, "Warning - Insufficient free space", "Cannot save a video because of insufficient free space", QMessageBox::Ok);
 				return;
 			}
 			
-			if (fileOverMaxSize && !insufficientFreeSpace_estimate) {//If file size is over 4GB and file system is FAT32
+			if (fileOverMaxSize && !insufficientFreeSpaceEstimate) {//If file size is over 4GB and file system is FAT32
 				QMessageBox::StandardButton reply;
 				reply = QMessageBox::warning(this, "Warning - File size over limit", "Estimated file size is larger than the 4GB limit for the the filesystem.\nAttempt to save anyway?", QMessageBox::Yes|QMessageBox::No);
 				if(QMessageBox::Yes != reply)
 					return;
 			}
 			
-			if (insufficientFreeSpace_estimate && !fileOverMaxSize) {
+			if (insufficientFreeSpaceEstimate && !fileOverMaxSize) {
 				QMessageBox::StandardButton reply;
 				reply = QMessageBox::warning(this, "Warning - Insufficient free space", "Estimated file size is larger than free space on drive.\nAttempt to save anyway?", QMessageBox::Yes|QMessageBox::No);
 				if(QMessageBox::Yes != reply)
 					return;
 			}
 			
-			if (fileOverMaxSize && insufficientFreeSpace_estimate){
+			if (fileOverMaxSize && insufficientFreeSpaceEstimate){
 				QMessageBox::StandardButton reply;
 				reply = QMessageBox::warning(this, "Warning - File size over limits", "Estimated file size is larger than free space on drive.\nEstimated file size is larger than the 4GB limit for the the filesystem.\nAttempt to save anyway?", QMessageBox::Yes|QMessageBox::No);
 				if(QMessageBox::Yes != reply)
@@ -393,8 +393,8 @@ void playbackWindow::checkForSaveDone()
 		but not if the save has already been aborted,
 		or if the save button is not enabled(unsafe to abort at that time)(except if save mode is RAW)*/
 		QSettings appSettings;
-		bool insufficientFreeSpace_current = (MIN_FREE_SPACE > statvfsBuf.f_bsize * (uint64_t)statvfsBuf.f_bfree);
-		if(insufficientFreeSpace_current &&
+		bool insufficientFreeSpaceCurrent = (MIN_FREE_SPACE > statvfsBuf.f_bsize * (uint64_t)statvfsBuf.f_bfree);
+		if(insufficientFreeSpaceCurrent &&
 		   !saveAborted &&
 				(ui->cmdSave->isEnabled() ||
 				appSettings.value("recorder/saveFormat", 0).toUInt() != SAVE_MODE_H264)

--- a/src/playbackwindow.h
+++ b/src/playbackwindow.h
@@ -89,6 +89,7 @@ private:
 	bool saveAborted;
 	bool insufficientFreeSpaceEstimate;
 	
+	unsigned int getSaveFormat();
 signals:
 	void finishedSaving();
 	void enableSaveSettingsButtons(bool);

--- a/src/playbackwindow.h
+++ b/src/playbackwindow.h
@@ -87,7 +87,7 @@ private:
 	bool autoSaveFlag;
 	bool settingsWindowIsOpen;
 	bool saveAborted;
-	bool insufficientFreeSpace_estimate;
+	bool insufficientFreeSpaceEstimate;
 	
 signals:
 	void finishedSaving();

--- a/src/playbackwindow.h
+++ b/src/playbackwindow.h
@@ -86,6 +86,7 @@ private:
 	Int32 playbackRate;
 	bool autoSaveFlag;
 	bool settingsWindowIsOpen;
+	bool saveAborted;
 
 signals:
 	void finishedSaving();

--- a/src/savesettingswindow.cpp
+++ b/src/savesettingswindow.cpp
@@ -53,7 +53,7 @@ saveSettingsWindow::saveSettingsWindow(QWidget *parent, Camera * camInst) :
 	
 	ui->spinBitrate->setValue(settings.value("recorder/bitsPerPixel", camera->recorder->bitsPerPixel).toDouble());
 	ui->spinMaxBitrate->setValue(settings.value("recorder/maxBitrate", camera->recorder->maxBitrate).toDouble());
-	ui->spinFramerate->setValue(settings.value("recorder/framerate", camera->recorder->framerate).toDouble());
+	ui->spinFramerate->setValue(settings.value("recorder/framerate", camera->recorder->framerate).toUInt());
 	ui->lineFilename->setText(settings.value("recorder/filename", camera->recorder->filename).toString());
 
 	refreshDriveList();


### PR DESCRIPTION
- Abort a save if there is less than 20MB free on the selected partition to avoid a crash if the camera reaches 0 bytes free space.
- Disallow starting of a save if space is below 20MB.
- When save is aborted manually or automatically, update the status window to reflect that.