### PR TITLE
Incremented bugfix number

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ chronos-cam-app_*.changes
 .DS_Store
 *\~
 .directory
+.idea

--- a/src/defines.h
+++ b/src/defines.h
@@ -25,7 +25,7 @@
 #define SERIAL_NUMBER_OFFSET	0
 #define SERIAL_NUMBER_MAX_LEN	32		//Maximum number of characters in serial number
 
-#define CAMERA_APP_VERSION		"0.7.1"
+#define CAMERA_APP_VERSION		"0.7.2"
 #define ACCEPTABLE_FPGA_VERSION	3
 
 // Network Storage Paths


### PR DESCRIPTION
0.7.2 release fixes the following issues

- NFS & SMB credentials now persist through reboot of camera when assigned in the camera GUI or the web interface.

Further information published at: https://forum.krontech.ca/index.php?topic=687.60